### PR TITLE
🔒 fix(backend): restrict CORS configuration to trusted frontend origins

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -5,7 +5,11 @@ const sqlite3 = require("sqlite3").verbose();
 const app = express();
 const PORT = process.env.PORT || 5001;
 // Middleware
-app.use(cors());
+const corsOptions = {
+    origin: process.env.FRONTEND_URL || "http://localhost:5173",
+    optionsSuccessStatus: 200
+};
+app.use(cors(corsOptions));
 app.use(express.json());
 // Database connection
 const dbPath = path.join(__dirname, "exports", "eso_catalog.db");


### PR DESCRIPTION
🎯 **What:** The `backend/server.js` previously used `app.use(cors())` with no arguments, defaulting to accepting requests from any origin (`Access-Control-Allow-Origin: *`).\n⚠️ **Risk:** Allowing arbitrary origins to make Cross-Origin Resource Sharing (CORS) requests exposes the API to CSRF-style attacks and data leakage if sensitive authenticated endpoints exist. Any malicious website could make API requests to this backend on behalf of a victim user.\n🛡️ **Solution:** Replaced the empty `cors()` call with a `corsOptions` object that specifies the `origin` property. It checks the `FRONTEND_URL` environment variable and falls back to `http://localhost:5173` (the default Vite dev server). This explicitly allows the trusted frontend domain while blocking all others.

---
*PR created automatically by Jules for task [1858306529954062733](https://jules.google.com/task/1858306529954062733) started by @RyanS4*