### PR TITLE
🧹 Remove unused lucide-react imports from navbar

### DIFF
--- a/frontend/src/components/ui/navbar.jsx
+++ b/frontend/src/components/ui/navbar.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Globe, Gamepad2, Monitor, Shield, Zap, User, Store, LogOut, Radio } from "lucide-react";
+import { Globe, Gamepad2, Monitor, Zap, User, LogOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ModeToggle } from "@/components/ui/mode-toggle";
 import { useTheme } from "@/components/theme-provider";


### PR DESCRIPTION
🎯 **What:** Removed unused icon imports (`Shield`, `Store`, `Radio`) from the `lucide-react` import statement in `frontend/src/components/ui/navbar.jsx`.
💡 **Why:** Having unused imports clutters the code, makes files longer than necessary, and can occasionally cause confusion about what dependencies a component actually uses. Removing them improves maintainability.
✅ **Verification:** Verified by checking that `npm run build` and `npm run lint` pass successfully in the `frontend` directory. The linter flagged other unused imports in other files, but correctly identified no issues with `navbar.jsx` after the change. No frontend tests exist.
✨ **Result:** A cleaner `navbar.jsx` component that correctly declares only the dependencies it actively uses.

---
*PR created automatically by Jules for task [3068353505465367808](https://jules.google.com/task/3068353505465367808) started by @RyanS4*