### PR TITLE
[Draft] Fix #20: Automated expired listing TTL purge triggers & scheduled background daemon

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -164,6 +164,10 @@ Key architectural components:
     ```
 *   **Response (200 OK):** `{"success": true, "count": 1}`
 
+#### `POST /api/market/listings/purge-expired`
+*   **Description:** Manually triggers an immediate TTL purge of expired guild trader listings across all servers. (Also runs automatically every hour via background timer).
+*   **Response (200 OK):** `{"success": true, "purged": 0, "message": "Successfully purged 0 expired listing(s)."}`
+
 #### `POST /api/inventory/sync`
 *   **Description:** Syncs duplicate inventory bags owned by a character to allow trading matches.
 *   **Body Payload:**

--- a/backend/data-pipeline/parse_esotrade_addon.py
+++ b/backend/data-pipeline/parse_esotrade_addon.py
@@ -211,6 +211,9 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
 
     listings = list(grouped_listings.values())
 
+    # Purge any expired listings prior to ingesting fresh scans
+    cursor.execute("DELETE FROM guild_trader_listings WHERE expires_at IS NOT NULL AND datetime(expires_at) < datetime('now');")
+
     affected_ids = set()
     if listings:
         print(f"Direct Ingesting {len(listings)} custom ESOTrade listings into database...")

--- a/backend/data-pipeline/parse_saved_variables.py
+++ b/backend/data-pipeline/parse_saved_variables.py
@@ -120,6 +120,9 @@ def parse_ttc_saved_variables(file_path, db_conn, server="NA"):
 
     print(f"Extracted {len(listings)} authentic player-scanned listings from SavedVariables ({server}).")
 
+    # Purge any expired listings prior to inserting fresh scans
+    cursor.execute("DELETE FROM guild_trader_listings WHERE expires_at IS NOT NULL AND datetime(expires_at) < datetime('now');")
+
     if listings:
         cursor.executemany("""
             INSERT INTO guild_trader_listings (game_item_id, server, price, quantity, guild_name, location, expires_at, discovered_at)

--- a/backend/data-pipeline/populate_sqlite.py
+++ b/backend/data-pipeline/populate_sqlite.py
@@ -120,8 +120,25 @@ def populate_database():
     );
     """)
 
-    # Create index
+    # Create indexes and TTL purge triggers
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_listings_game_item_id ON guild_trader_listings(game_item_id);")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_listings_expires_at ON guild_trader_listings(expires_at);")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS trg_purge_expired_listings_insert
+        AFTER INSERT ON guild_trader_listings
+        WHEN NEW.expires_at IS NOT NULL AND datetime(NEW.expires_at) < datetime('now')
+        BEGIN
+            DELETE FROM guild_trader_listings WHERE id = NEW.id;
+        END;
+    """)
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS trg_purge_expired_listings_update
+        AFTER UPDATE OF expires_at ON guild_trader_listings
+        WHEN NEW.expires_at IS NOT NULL AND datetime(NEW.expires_at) < datetime('now')
+        BEGIN
+            DELETE FROM guild_trader_listings WHERE id = NEW.id;
+        END;
+    """)
 
     # Create helper function to generate uuid-like strings or use sequential keys since SQLite doesn't have native UUIDs
     # ZeniMax game_item_id is unique, so we can use "item_ID" as the text PK id

--- a/backend/data-pipeline/test_api_endpoints.js
+++ b/backend/data-pipeline/test_api_endpoints.js
@@ -36,6 +36,32 @@ function httpGet(path) {
     });
 }
 
+function httpPost(path, body = {}) {
+    return new Promise((resolve, reject) => {
+        const payload = JSON.stringify(body);
+        const req = http.request(`http://localhost:${PORT}${path}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(payload)
+            }
+        }, (res) => {
+            let data = '';
+            res.on('data', chunk => data += chunk);
+            res.on('end', () => {
+                try {
+                    resolve({ status: res.statusCode, data: JSON.parse(data) });
+                } catch (e) {
+                    resolve({ status: res.statusCode, raw: data });
+                }
+            });
+        });
+        req.on('error', err => reject(err));
+        req.write(payload);
+        req.end();
+    });
+}
+
 async function runTests() {
     // Wait 1.5s for server to start
     await new Promise(r => setTimeout(r, 1500));
@@ -64,6 +90,13 @@ async function runTests() {
         console.log("\n4. Testing GET /api/items?limit=2...");
         const itemsRes = await httpGet('/api/items?limit=2');
         console.log(`   Status: ${itemsRes.status}, Total catalog items: ${itemsRes.data.total}`);
+
+        console.log("\n5. Testing POST /api/market/listings/purge-expired...");
+        const purgeRes = await httpPost('/api/market/listings/purge-expired');
+        console.log(`   Status: ${purgeRes.status}, Purge Result: ${JSON.stringify(purgeRes.data)}`);
+        if (purgeRes.status !== 200 || !purgeRes.data.success) {
+            throw new Error(`TTL Purge endpoint failed with status ${purgeRes.status}`);
+        }
 
         console.log("\nAll API endpoint tests passed successfully!");
     } catch (err) {

--- a/backend/data-pipeline/test_ttl_purge.py
+++ b/backend/data-pipeline/test_ttl_purge.py
@@ -1,0 +1,100 @@
+import sqlite3
+import os
+import sys
+import datetime
+
+sys.stdout.reconfigure(encoding='utf-8')
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DB_PATH = os.path.abspath(os.path.join(SCRIPT_DIR, "..", "exports", "eso_catalog.db"))
+
+def test_ttl_purge():
+    print(f"Connecting to database at {DB_PATH}...")
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+
+    # Step 1: Ensure triggers and indexes exist
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_listings_expires_at ON guild_trader_listings(expires_at);")
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS trg_purge_expired_listings_insert
+        AFTER INSERT ON guild_trader_listings
+        WHEN NEW.expires_at IS NOT NULL AND datetime(NEW.expires_at) < datetime('now')
+        BEGIN
+            DELETE FROM guild_trader_listings WHERE id = NEW.id;
+        END;
+    """)
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS trg_purge_expired_listings_update
+        AFTER UPDATE OF expires_at ON guild_trader_listings
+        WHEN NEW.expires_at IS NOT NULL AND datetime(NEW.expires_at) < datetime('now')
+        BEGIN
+            DELETE FROM guild_trader_listings WHERE id = NEW.id;
+        END;
+    """)
+    conn.commit()
+
+    # Pick a valid game_item_id from items table
+    cursor.execute("SELECT game_item_id FROM items LIMIT 1;")
+    sample_item = cursor.fetchone()
+    assert sample_item is not None, "No items found in items table!"
+    item_id = sample_item[0]
+    print(f"Using game_item_id: {item_id}")
+
+    # Clean up test rows first if any exist
+    cursor.execute("DELETE FROM guild_trader_listings WHERE guild_name = '__TEST_TTL_GUILD__';")
+    conn.commit()
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    past_date = (now - datetime.timedelta(days=2)).strftime("%Y-%m-%d %H:%M:%S")
+    future_date = (now + datetime.timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
+
+    print("\n--- Test 1: Insert Already-Expired Listing (Trigger Auto-Purge) ---")
+    cursor.execute("""
+        INSERT INTO guild_trader_listings 
+        (game_item_id, server, seller_name, price, quantity, guild_name, location, expires_at)
+        VALUES (?, 'NA', '@TestSellerExpired', 100, 1, '__TEST_TTL_GUILD__', 'Test Location', ?);
+    """, (item_id, past_date))
+    conn.commit()
+
+    cursor.execute("SELECT COUNT(*) FROM guild_trader_listings WHERE guild_name = '__TEST_TTL_GUILD__' AND seller_name = '@TestSellerExpired';")
+    count_expired = cursor.fetchone()[0]
+    print(f"Expired listings found immediately after insert: {count_expired} (Expected: 0)")
+    assert count_expired == 0, "Expected trigger to auto-purge already-expired listing on insert!"
+    print("PASS: Insert trigger successfully purged expired listing.")
+
+    print("\n--- Test 2: Insert Active Listing (Should Persist) ---")
+    cursor.execute("""
+        INSERT INTO guild_trader_listings 
+        (game_item_id, server, seller_name, price, quantity, guild_name, location, expires_at)
+        VALUES (?, 'NA', '@TestSellerActive', 500, 1, '__TEST_TTL_GUILD__', 'Test Location', ?);
+    """, (item_id, future_date))
+    conn.commit()
+
+    cursor.execute("SELECT COUNT(*) FROM guild_trader_listings WHERE guild_name = '__TEST_TTL_GUILD__' AND seller_name = '@TestSellerActive';")
+    count_active = cursor.fetchone()[0]
+    print(f"Active listings found: {count_active} (Expected: 1)")
+    assert count_active == 1, "Expected active listing to persist!"
+    print("PASS: Active listing persisted as expected.")
+
+    print("\n--- Test 3: Update Active Listing to Expired Date (Trigger Auto-Purge) ---")
+    cursor.execute("""
+        UPDATE guild_trader_listings 
+        SET expires_at = ? 
+        WHERE guild_name = '__TEST_TTL_GUILD__' AND seller_name = '@TestSellerActive';
+    """, (past_date,))
+    conn.commit()
+
+    cursor.execute("SELECT COUNT(*) FROM guild_trader_listings WHERE guild_name = '__TEST_TTL_GUILD__' AND seller_name = '@TestSellerActive';")
+    count_updated = cursor.fetchone()[0]
+    print(f"Listings found after expiring via UPDATE: {count_updated} (Expected: 0)")
+    assert count_updated == 0, "Expected update trigger to auto-purge expired listing on update!"
+    print("PASS: Update trigger successfully purged expired listing.")
+
+    # Cleanup
+    cursor.execute("DELETE FROM guild_trader_listings WHERE guild_name = '__TEST_TTL_GUILD__';")
+    conn.commit()
+    conn.close()
+    print("\nALL TTL PURGE TESTS PASSED SUCCESSFULLY!")
+
+if __name__ == "__main__":
+    test_ttl_purge()

--- a/backend/data-pipeline/watcher.py
+++ b/backend/data-pipeline/watcher.py
@@ -14,12 +14,14 @@ import os
 import sys
 import time
 import subprocess
+import sqlite3
 
 sys.stdout.reconfigure(encoding='utf-8')
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PARSER_TTC = os.path.join(SCRIPT_DIR, "parse_saved_variables.py")
 PARSER_ESOTRADE = os.path.join(SCRIPT_DIR, "parse_esotrade_addon.py")
+DB_PATH = os.path.abspath(os.path.join(SCRIPT_DIR, "..", "exports", "eso_catalog.db"))
 
 WATCH_PATHS = [
     os.path.expanduser("~/Documents/Elder Scrolls Online/live/SavedVariables/ESOTrade.lua"),
@@ -28,15 +30,44 @@ WATCH_PATHS = [
     os.path.expanduser("~/OneDrive/Documents/Elder Scrolls Online/live/SavedVariables/TamrielTradeCentre.lua"),
 ]
 
-def start_watching(poll_interval=2):
+PURGE_INTERVAL_SECONDS = 3600  # 1 hour
+
+def purge_expired_listings(db_path=DB_PATH):
+    """Purges listings past their TTL expires_at timestamp directly from SQLite."""
+    if not os.path.exists(db_path):
+        return 0
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM guild_trader_listings WHERE expires_at IS NOT NULL AND datetime(expires_at) < datetime('now');")
+        purged = cursor.rowcount
+        conn.commit()
+        conn.close()
+        if purged > 0:
+            print(f"[{time.strftime('%H:%M:%S')}] [TTL Purge] Purged {purged} expired guild trader listings from database.")
+        return purged
+    except Exception as e:
+        print(f"[{time.strftime('%H:%M:%S')}] [TTL Purge Error] Failed to purge expired listings: {e}")
+        return 0
+
+def start_watching(poll_interval=2, purge_interval=PURGE_INTERVAL_SECONDS):
     print("================================================================")
     print("=== REAL-TIME ESO TRADE ADDON & SAVEDVARIABLES WATCHER DAEMON ===")
     print("================================================================")
     
     last_mtimes = {}
 
+    # Run initial startup TTL purge
+    purge_expired_listings(DB_PATH)
+    last_purge_time = time.time()
+
     try:
         while True:
+            current_time = time.time()
+            if current_time - last_purge_time >= purge_interval:
+                purge_expired_listings(DB_PATH)
+                last_purge_time = current_time
+
             for path in WATCH_PATHS:
                 if os.path.exists(path):
                     mtime = os.path.getmtime(path)

--- a/backend/server.js
+++ b/backend/server.js
@@ -155,6 +155,25 @@ function initializeDatabaseSchema() {
             ON guild_trader_listings (game_item_id, server, guild_name, seller_name, price, quantity, level, quality, trait_id);
         `);
         db.run("CREATE INDEX IF NOT EXISTS idx_listings_game_item_id ON guild_trader_listings(game_item_id);");
+        db.run("CREATE INDEX IF NOT EXISTS idx_listings_expires_at ON guild_trader_listings(expires_at);");
+
+        // SQLite triggers for automated expired listing TTL purging on insert & update
+        db.run(`
+            CREATE TRIGGER IF NOT EXISTS trg_purge_expired_listings_insert
+            AFTER INSERT ON guild_trader_listings
+            WHEN NEW.expires_at IS NOT NULL AND datetime(NEW.expires_at) < datetime('now')
+            BEGIN
+                DELETE FROM guild_trader_listings WHERE id = NEW.id;
+            END;
+        `);
+        db.run(`
+            CREATE TRIGGER IF NOT EXISTS trg_purge_expired_listings_update
+            AFTER UPDATE OF expires_at ON guild_trader_listings
+            WHEN NEW.expires_at IS NOT NULL AND datetime(NEW.expires_at) < datetime('now')
+            BEGIN
+                DELETE FROM guild_trader_listings WHERE id = NEW.id;
+            END;
+        `);
     });
 }
 /**
@@ -306,6 +325,27 @@ const dbAll = (sql, params = []) => new Promise((resolve, reject) => {
         else resolve(rows);
     });
 });
+
+/**
+ * Purges expired guild trader listings from the database.
+ */
+async function purgeExpiredListings() {
+    try {
+        const result = await dbRun("DELETE FROM guild_trader_listings WHERE expires_at IS NOT NULL AND datetime(expires_at) < datetime('now')");
+        if (result && result.changes > 0) {
+            console.log(`[TTL Purge] Purged ${result.changes} expired guild trader listings.`);
+        }
+        return result ? result.changes : 0;
+    } catch (err) {
+        console.error("[TTL Purge Error] Failed to purge expired listings:", err.message);
+        return 0;
+    }
+}
+
+// Background automated periodic TTL purge every hour (3,600,000 ms)
+const TTL_PURGE_INTERVAL_MS = 60 * 60 * 1000;
+setInterval(purgeExpiredListings, TTL_PURGE_INTERVAL_MS);
+setTimeout(purgeExpiredListings, 2000);
 
 /**
  * GET /api/status
@@ -1473,6 +1513,23 @@ app.post("/api/market/upload-scans", async (req, res) => {
         });
     } catch (err) {
         console.error("Error in upload-scans:", err.message);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+/**
+ * POST /api/market/listings/purge-expired
+ * Manually trigger an immediate TTL purge of expired guild trader listings.
+ */
+app.post("/api/market/listings/purge-expired", async (req, res) => {
+    try {
+        const purgedCount = await purgeExpiredListings();
+        res.json({
+            success: true,
+            purged: purgedCount,
+            message: `Successfully purged ${purgedCount} expired listing(s).`
+        });
+    } catch (err) {
         res.status(500).json({ error: err.message });
     }
 });

--- a/docs/DatabaseSchema.md
+++ b/docs/DatabaseSchema.md
@@ -196,3 +196,10 @@ ORDER BY p.suggested_price ASC;
 
 ### First-Class Identifiers
 While `uuid` remains the Primary Key for internal database integrity, the `game_item_id` is uniquely indexed. All ingestion pipelines (TTC, Addon syncs) will use `game_item_id` for UPSERT operations.
+
+### Automated Listing TTL Purge & Triggers
+To prevent database bloating and ensure only active market listings are presented:
+- **SQLite Triggers**: `trg_purge_expired_listings_insert` and `trg_purge_expired_listings_update` automatically delete listings where `expires_at` is older than `datetime('now')` upon insertion or update.
+- **Background Cron / Scheduled Daemon**: Both the Node.js Express backend (`server.js`) and the Python file watcher daemon (`watcher.py`) run hourly periodic purges executing `DELETE FROM guild_trader_listings WHERE expires_at IS NOT NULL AND datetime(expires_at) < datetime('now');`.
+- **Index**: `idx_listings_expires_at` on `guild_trader_listings(expires_at)` provides high-performance TTL range queries and rapid purges.
+

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -97,6 +97,20 @@ export async function clearAllListings() {
     }
 }
 
+export async function purgeExpiredListings() {
+    try {
+        const response = await fetch(`${BASE_URL}/api/market/listings/purge-expired`, {
+            method: 'POST',
+            headers: getHeaders()
+        });
+        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+        return await response.json();
+    } catch (error) {
+        console.error('Error purging expired listings:', error);
+        return { success: false, error: error.message };
+    }
+}
+
 // ============================================================================
 // AUTHENTICATION & DEV ACCOUNTS API HELPERS
 // ============================================================================


### PR DESCRIPTION
## Summary
Resolves #20 by implementing an automated multi-layered TTL (Time-To-Live) purge mechanism for expired guild trader listings in SQLite.

## Problem
Previously, expired listings in `guild_trader_listings` (where `expires_at < now`) were only cleaned up when a new scan batch was uploaded through the `/api/market/upload-scans` or `/api/listings/sync` endpoints. In the absence of incoming scans, stale listings would accumulate in the database.

## Solution & Changes
1. **SQLite Database Triggers & Indexing**:
   - Added index `idx_listings_expires_at` on `guild_trader_listings(expires_at)` for high-performance datetime queries and rapid deletions.
   - Added `trg_purge_expired_listings_insert` SQLite trigger (`AFTER INSERT`) that immediately removes any inserted listing that is already past its expiration date.
   - Added `trg_purge_expired_listings_update` SQLite trigger (`AFTER UPDATE OF expires_at`) that immediately removes listings modified to an expired timestamp.
2. **Automated Scheduled Background Purge**:
   - **Node.js Express Backend (`server.js`)**: Added `purgeExpiredListings()` helper running on database initialization and on an hourly background `setInterval(purgeExpiredListings, 60 * 60 * 1000)`.
   - **Python Watcher Daemon (`watcher.py`)**: Added hourly TTL purge check in the main polling loop as well as on daemon startup.
   - **Data Ingestion Scripts (`parse_esotrade_addon.py`, `parse_saved_variables.py`, `populate_sqlite.py`)**: Ensured expired listings are systematically purged during batch ingests and migrations.
3. **API & Management Endpoints**:
   - Added `POST /api/market/listings/purge-expired` endpoint for manual on-demand triggers and diagnostic status reporting.
   - Added `purgeExpiredListings()` helper to frontend API client `frontend/src/api/api.js`.
4. **Testing & Documentation**:
   - Added automated test script `backend/data-pipeline/test_ttl_purge.py` testing trigger deletions, persistence of active listings, and update auto-purges.
   - Extended `backend/data-pipeline/test_api_endpoints.js` integration test suite to verify `POST /api/market/listings/purge-expired`.
   - Updated `docs/DatabaseSchema.md` and `backend/README.md` to document the automated listing TTL purge architecture.

## Verification
- `python backend/data-pipeline/test_ttl_purge.py`: All 3 trigger & purge test scenarios passed.
- `node backend/data-pipeline/test_api_endpoints.js`: All 5 API endpoint tests passed with code 200.
- `python backend/data-pipeline/test_db_queries.py`: Database queries verified.
- `npm run build` in `frontend/`: Zero build errors.

Closes #20