### PR TITLE
[Draft] Fix #32: Remove hardcoded password123 default in DevAccountModal

### DIFF
--- a/frontend/src/components/dev/DevAccountModal.jsx
+++ b/frontend/src/components/dev/DevAccountModal.jsx
@@ -10,7 +10,7 @@ export default function DevAccountModal({ isOpen, onClose }) {
     const [editingUserId, setEditingUserId] = useState(null);
     const [editForm, setEditForm] = useState({ username: '', email: '', eso_handle: '', role: 'user' });
     const [showCreate, setShowCreate] = useState(false);
-    const [createForm, setCreateForm] = useState({ username: '', email: '', password: 'password123', eso_handle: '' });
+    const [createForm, setCreateForm] = useState({ username: '', email: '', password: '', eso_handle: '' });
 
     const loadUsers = async () => {
         setLoading(true);
@@ -27,7 +27,7 @@ export default function DevAccountModal({ isOpen, onClose }) {
         }
     }, [isOpen]);
 
-    if (!isOpen) return null;
+    if (!isOpen || import.meta.env.PROD) return null;
 
     const handleBypass = async (userId) => {
         const res = await devBypass(userId);
@@ -72,7 +72,7 @@ export default function DevAccountModal({ isOpen, onClose }) {
         const res = await registerUser(createForm.username, createForm.email, createForm.password, createForm.eso_handle);
         if (res.success) {
             setShowCreate(false);
-            setCreateForm({ username: '', email: '', password: 'password123', eso_handle: '' });
+            setCreateForm({ username: '', email: '', password: '', eso_handle: '' });
             loadUsers();
         } else {
             alert("Create failed: " + res.error);
@@ -120,7 +120,7 @@ export default function DevAccountModal({ isOpen, onClose }) {
 
                 {/* Create Quick User Form */}
                 {showCreate && (
-                    <form onSubmit={handleCreateAccount} className="mb-4 p-4 bg-[#0a0a0d] border border-[#c5a059]/30 grid grid-cols-1 md:grid-cols-4 gap-3">
+                    <form onSubmit={handleCreateAccount} className="mb-4 p-4 bg-[#0a0a0d] border border-[#c5a059]/30 grid grid-cols-1 md:grid-cols-5 gap-3">
                         <input
                             type="text"
                             placeholder="Username"
@@ -134,6 +134,14 @@ export default function DevAccountModal({ isOpen, onClose }) {
                             placeholder="Email"
                             value={createForm.email}
                             onChange={(e) => setCreateForm({ ...createForm, email: e.target.value })}
+                            className="px-3 py-1.5 bg-[#121218] border border-[#2a2c33] text-xs text-[#e0d8c3] focus:border-[#c5a059] focus:outline-none"
+                            required
+                        />
+                        <input
+                            type="password"
+                            placeholder="Password"
+                            value={createForm.password}
+                            onChange={(e) => setCreateForm({ ...createForm, password: e.target.value })}
                             className="px-3 py-1.5 bg-[#121218] border border-[#2a2c33] text-xs text-[#e0d8c3] focus:border-[#c5a059] focus:outline-none"
                             required
                         />

--- a/frontend/src/components/ui/navbar.jsx
+++ b/frontend/src/components/ui/navbar.jsx
@@ -118,17 +118,19 @@ function Navbar() {
               )}
             </div>
 
-            {/* Developer Bypass Button */}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setIsDevModalOpen(true)}
-              className="rounded-none gap-1.5 font-bold cursor-pointer bg-amber-950/30 hover:bg-amber-900/50 text-[#d4af37] border-[#c5a059]/40 hover:border-[#c5a059] shadow-sm transition-all text-xs"
-              title="Open Developer Account Switcher & Bypass Panel"
-            >
-              <Zap className="size-3.5 text-[#c5a059] fill-[#c5a059]" />
-              <span>[DEV] Accounts</span>
-            </Button>
+            {/* Developer Bypass Button (Dev mode only) */}
+            {!import.meta.env.PROD && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsDevModalOpen(true)}
+                className="rounded-none gap-1.5 font-bold cursor-pointer bg-amber-950/30 hover:bg-amber-900/50 text-[#d4af37] border-[#c5a059]/40 hover:border-[#c5a059] shadow-sm transition-all text-xs"
+                title="Open Developer Account Switcher & Bypass Panel"
+              >
+                <Zap className="size-3.5 text-[#c5a059] fill-[#c5a059]" />
+                <span>[DEV] Accounts</span>
+              </Button>
+            )}
 
             {/* Active Session Badge */}
             {user ? (
@@ -217,7 +219,9 @@ function Navbar() {
       </header>
 
       {/* Developer Account Switcher Modal */}
-      <DevAccountModal isOpen={isDevModalOpen} onClose={() => setIsDevModalOpen(false)} />
+      {!import.meta.env.PROD && (
+        <DevAccountModal isOpen={isDevModalOpen} onClose={() => setIsDevModalOpen(false)} />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
Resolves #32 by eliminating the hardcoded default `password123` value from `frontend/src/components/dev/DevAccountModal.jsx`, adding an explicit required password input field, and gating developer panel components in production builds.

## Key Changes
- **Dev Account Modal**:
  - Initialized `createForm.password` with empty string `''` instead of `'password123'`.
  - Reset form with `password: ''` upon submission.
  - Added `<input type="password" placeholder="Password" ... required />` to the new user creation form and expanded grid to 5 columns.
  - Guarded modal rendering with `if (!isOpen || import.meta.env.PROD) return null;`.
- **Navbar UI**:
  - Gated the `[DEV] Accounts` trigger button and `<DevAccountModal />` behind `!import.meta.env.PROD`.

## Verification
- Verified production build compiles cleanly without errors (`npm run build`).
- Verified backend integration test suite (`node data-pipeline/test_api_endpoints.js`).

Closes #32