### PR TITLE
fix(scraper): handle child process error event in live trader extraction endpoint (closes #62)

### DIFF
--- a/backend/data-pipeline/test_api_endpoints.js
+++ b/backend/data-pipeline/test_api_endpoints.js
@@ -509,12 +509,20 @@ async function runTests() {
         if (authDelWatch.status !== 200) throw new Error(`Expected 200 for auth watchlist delete, got ${authDelWatch.status}`);
         console.log("   Watchlist delete auth & IDOR protection verified!");
 
+        console.log("\n32. Testing POST /api/market/listings/extract child process & input validation...");
+        const emptyExtract = await httpPost('/api/market/listings/extract', {});
+        if (emptyExtract.status !== 400) throw new Error(`Expected 400 for empty extract request, got ${emptyExtract.status}`);
+        const validExtract = await httpPost('/api/market/listings/extract', { search: "Mother's Sorrow", server: "NA" });
+        if (validExtract.status !== 200) throw new Error(`Expected 200 for valid extract request, got ${validExtract.status}`);
+        if (!validExtract.data.success) throw new Error(`Expected success=true from extract endpoint`);
+        console.log("   Scraper child process execution & validation verified without server crash!");
+
         // Cleanup test character
         await httpDelete(`/api/characters/${securedCharId}`, {
             'Authorization': `Bearer ${bypassRes.data.token}`
         });
 
-        console.log("\nAll 31 API endpoint test suites passed successfully!");
+        console.log("\nAll 32 API endpoint test suites passed successfully!");
     } catch (err) {
         console.error("API test failed:", err);
         process.exitCode = 1;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1624,6 +1624,7 @@ app.post("/api/market/listings/extract", async (req, res) => {
 
     const targetServer = server || "NA";
     const { spawn } = require("child_process");
+    let hasResponded = false;
 
     try {
         const pyScript = path.join(__dirname, "data-pipeline", "live_trader_extractor.py");
@@ -1631,24 +1632,38 @@ app.post("/api/market/listings/extract", async (req, res) => {
             env: process.env
         });
 
+        pyProcess.on("error", (err) => {
+            console.error(`[Scraper Error]: Failed to spawn child process: ${err.message}`);
+            if (!hasResponded) {
+                hasResponded = true;
+                res.status(500).json({
+                    error: `Failed to execute scraper process: ${err.message}`,
+                    success: false
+                });
+            }
+        });
+
         pyProcess.on("close", async (code) => {
+            if (hasResponded) return;
+            hasResponded = true;
+
             console.log(`Live extraction process finished with code ${code}`);
             try {
                 const query = `
                     SELECT 
                         gtl.id AS listing_id, gtl.game_item_id, gtl.server, gtl.price, gtl.quantity,
                         gtl.guild_name, gtl.location, gtl.expires_at, gtl.discovered_at,
-                        i.name AS item_name, i.icon_url AS item_icon, i.category AS item_category,
-                        i.subcategory AS item_subcategory, i.rarity AS item_rarity, i.metadata AS item_metadata,
+                        COALESCE(gtl.item_name, i.name) AS item_name, i.icon_url AS item_icon, i.category AS item_category,
+                        i.subcategory AS item_subcategory, COALESCE(gtl.quality, i.rarity, 1) AS item_rarity, i.metadata AS item_metadata,
                         ip.suggested_price, ip.avg_price,
                         CASE WHEN gtl.price > 0 THEN CAST(ip.suggested_price AS REAL) / gtl.price ELSE 0 END AS value_index
                     FROM guild_trader_listings gtl
                     JOIN items i ON gtl.game_item_id = i.game_item_id
                     LEFT JOIN item_prices ip ON gtl.game_item_id = ip.game_item_id AND gtl.server = ip.server
-                    WHERE gtl.server = ? AND i.name LIKE ?
+                    WHERE gtl.server = ? AND (i.name LIKE ? OR gtl.item_name LIKE ?)
                     ORDER BY value_index DESC, gtl.price ASC;
                 `;
-                const rows = await dbAll(query, [targetServer, `%${search}%`]);
+                const rows = await dbAll(query, [targetServer, `%${search}%`, `%${search}%`]);
                 const listings = rows.map(r => {
                     try { r.item_metadata = JSON.parse(r.item_metadata); } catch(e) { r.item_metadata = {}; }
                     return r;
@@ -1659,7 +1674,10 @@ app.post("/api/market/listings/extract", async (req, res) => {
             }
         });
     } catch (err) {
-        res.status(500).json({ error: err.message });
+        if (!hasResponded) {
+            hasResponded = true;
+            res.status(500).json({ error: err.message });
+        }
     }
 });
 


### PR DESCRIPTION
### Summary of Changes
- Attached `'error'` event listener to `pyProcess` inside `POST /api/market/listings/extract` in `backend/server.js` to catch spawn/OS-level errors and prevent unhandled exceptions from terminating the Express server.
- Added `hasResponded` state guard ensuring only one HTTP response is sent if error and close events fire sequentially.
- Updated extract route query to prioritize `COALESCE(gtl.item_name, i.name)` and `COALESCE(gtl.quality, i.rarity, 1)`.
- Added Test Suite 32 to `backend/data-pipeline/test_api_endpoints.js` verifying input validation and scraper execution without server crashes.

Closes #62