### PR TITLE
fix(pipeline): restore TLS certificate and hostname verification in live trader extractor (closes #64)

### DIFF
--- a/backend/data-pipeline/live_trader_extractor.py
+++ b/backend/data-pipeline/live_trader_extractor.py
@@ -41,11 +41,9 @@ DEFAULT_TRADE_ITEMS = [
 
 def get_ttc_item_id(item_name):
     """
-    Fetches TTC internal ItemID via AutoComplete API.
+    Fetches TTC internal ItemID via AutoComplete API with standard TLS certificate validation.
     """
     ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
 
     url = f"https://us.tamrieltradecentre.com/api/pc/Trade/GetItemAutoComplete?term={urllib.parse.quote(item_name)}"
     headers = {


### PR DESCRIPTION
### Summary of Changes
- Removed insecure `ctx.check_hostname = False` and `ctx.verify_mode = ssl.CERT_NONE` overrides from `get_ttc_item_id()` in `backend/data-pipeline/live_trader_extractor.py`.
- Restored standard default TLS certificate verification and hostname checking using `ssl.create_default_context()`.
- Verified live item ID resolution against TTC endpoint and validated all 32 backend test suites and pipeline tests.

Closes #64