### PR TITLE
fix(a11y): improve WCAG contrast ratios and add ARIA dialog/combobox landmarks (closes #17)

### DIFF
--- a/frontend/src/components/character/CharacterProfileModal.jsx
+++ b/frontend/src/components/character/CharacterProfileModal.jsx
@@ -89,17 +89,35 @@ export function CharacterProfileModal({ character, onClose }) {
     return traits;
   }, [gearBySlot]);
 
+  // Escape key handler
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    }
+    if (character) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [character, onClose]);
+
   if (!character) return null;
 
   const allianceInfo = ALLIANCE_NAMES[character.alliance] || ALLIANCE_NAMES[1];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-md p-4 overflow-y-auto">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Character Equipment Profile for ${character.name}`}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-md p-4 overflow-y-auto"
+    >
       <div className="w-full max-w-6xl rounded-none bg-[#121218] border-2 border-[#c5a059]/60 p-6 text-[#e0d8c3] shadow-2xl space-y-6 my-auto">
         {/* Header Bar */}
         <div className="flex items-center justify-between border-b border-[#2a2c33] pb-4">
           <div className="flex items-center gap-3">
-            <div className="size-12 rounded-none border-2 border-[#c5a059] bg-[#0a0a0d] flex items-center justify-center p-1">
+            <div className="size-12 rounded-none border-2 border-[#c5a059] bg-[#0a0a0d] flex items-center justify-center p-1" aria-hidden="true">
               {getAllianceIcon(character.alliance, "size-8")}
             </div>
             <div>
@@ -109,11 +127,11 @@ export function CharacterProfileModal({ character, onClose }) {
                 </h2>
                 {Boolean(character.master_crafter_unlocked) && (
                   <span className="px-2 py-0.5 bg-[#c5a059]/20 border border-[#c5a059] text-[#d4af37] text-[10px] font-cinzel font-bold uppercase flex items-center gap-1">
-                    <Award className="size-3 text-[#c5a059]" /> Master Crafter
+                    <Award className="size-3 text-[#c5a059]" aria-hidden="true" /> Master Crafter
                   </span>
                 )}
               </div>
-              <p className="text-xs text-[#8a8275] font-mono mt-0.5">
+              <p className="text-xs text-[#b0a696] font-mono mt-0.5">
                 Level {character.level || 50} • {character.class || "Dragonknight"} • {allianceInfo.name}
               </p>
             </div>
@@ -121,19 +139,21 @@ export function CharacterProfileModal({ character, onClose }) {
 
           <div className="flex items-center gap-3">
             {/* Active Bar Toggle */}
-            <div className="flex items-center gap-1 bg-[#0a0a0d] p-1 border border-[#2a2c33]">
+            <div className="flex items-center gap-1 bg-[#0a0a0d] p-1 border border-[#2a2c33]" role="group" aria-label="Weapon Bar Selection">
               <button
+                type="button"
                 onClick={() => setActiveWeaponBar("front")}
-                className={`px-3 py-1 text-xs font-cinzel font-bold uppercase border transition-all ${
-                  activeWeaponBar === "front" ? "bg-[#c5a059] text-[#0a0a0d] border-[#c5a059]" : "text-[#8a8275] border-transparent hover:text-[#e0d8c3]"
+                className={`px-3 py-1 text-xs font-cinzel font-bold uppercase border transition-all cursor-pointer ${
+                  activeWeaponBar === "front" ? "bg-[#c5a059] text-[#0a0a0d] border-[#c5a059]" : "text-[#b0a696] border-transparent hover:text-[#e0d8c3]"
                 }`}
               >
                 Front Bar
               </button>
               <button
+                type="button"
                 onClick={() => setActiveWeaponBar("back")}
-                className={`px-3 py-1 text-xs font-cinzel font-bold uppercase border transition-all ${
-                  activeWeaponBar === "back" ? "bg-[#c5a059] text-[#0a0a0d] border-[#c5a059]" : "text-[#8a8275] border-transparent hover:text-[#e0d8c3]"
+                className={`px-3 py-1 text-xs font-cinzel font-bold uppercase border transition-all cursor-pointer ${
+                  activeWeaponBar === "back" ? "bg-[#c5a059] text-[#0a0a0d] border-[#c5a059]" : "text-[#b0a696] border-transparent hover:text-[#e0d8c3]"
                 }`}
               >
                 Back Bar
@@ -141,10 +161,12 @@ export function CharacterProfileModal({ character, onClose }) {
             </div>
 
             <button
+              type="button"
               onClick={onClose}
-              className="p-1.5 rounded-none text-[#8a8275] hover:text-[#e0d8c3] hover:bg-[#161620]"
+              aria-label="Close character profile modal"
+              className="p-1.5 rounded-none text-[#b0a696] hover:text-[#e0d8c3] hover:bg-[#161620] cursor-pointer"
             >
-              <X className="size-5" />
+              <X className="size-5" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/frontend/src/components/dev/DevAccountModal.jsx
+++ b/frontend/src/components/dev/DevAccountModal.jsx
@@ -90,27 +90,50 @@ export default function DevAccountModal({ isOpen, onClose }) {
         }
     };
 
+    // Escape key handler
+    useEffect(() => {
+        function handleKeyDown(e) {
+            if (e.key === 'Escape') {
+                onClose();
+            }
+        }
+        if (isOpen) {
+            document.addEventListener('keydown', handleKeyDown);
+        }
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen, onClose]);
+
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-sm p-4">
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Developer Account Manager & Bypass Vault"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 backdrop-blur-sm p-4"
+        >
             <div className="relative w-full max-w-4xl rounded-none bg-[#121218] border-2 border-[#c5a059]/60 p-6 text-[#e0d8c3] shadow-2xl max-h-[90vh] flex flex-col">
                 
                 {/* Modal Header */}
                 <div className="flex items-center justify-between border-b border-[#2a2c33] pb-4 mb-4">
                     <div className="flex items-center gap-3">
-                        <div className="p-2 rounded-none bg-[#0a0a0d] border border-[#c5a059]/40 text-[#c5a059]">
+                        <div className="p-2 rounded-none bg-[#0a0a0d] border border-[#c5a059]/40 text-[#c5a059]" aria-hidden="true">
                             <Shield className="w-6 h-6" />
                         </div>
                         <div>
                             <h2 className="font-cinzel text-xl font-bold tracking-wide text-[#e0d8c3] flex items-center gap-2 uppercase">
                                 [DEV] Account Manager & Bypass Vault
                             </h2>
-                            <p className="text-xs text-[#d4af37]/80">
+                            <p className="text-xs text-[#d4af37]">
                                 1-Click developer account switching, editing, and instant session bypass.
                             </p>
                         </div>
                     </div>
-                    <button onClick={onClose} className="p-2 rounded-none bg-[#0a0a0d] border border-[#2a2c33] hover:border-[#c5a059]/40 text-[#a89f91] hover:text-[#e0d8c3] transition-colors">
-                        <X className="w-5 h-5" />
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        aria-label="Close Developer Account Manager modal"
+                        className="p-2 rounded-none bg-[#0a0a0d] border border-[#2a2c33] hover:border-[#c5a059]/40 text-[#b0a696] hover:text-[#e0d8c3] transition-colors cursor-pointer"
+                    >
+                        <X className="w-5 h-5" aria-hidden="true" />
                     </button>
                 </div>
 

--- a/frontend/src/components/ui/eso-select.jsx
+++ b/frontend/src/components/ui/eso-select.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useId } from "react";
 import { ChevronDown, Check } from "lucide-react";
 
 export function EsoSelect({
@@ -6,10 +6,13 @@ export function EsoSelect({
   onChange,
   options = [],
   placeholder = "Select Option",
-  className = ""
+  className = "",
+  "aria-label": ariaLabel
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const containerRef = useRef(null);
+  const listboxId = useId();
 
   const selectedOption = options.find((opt) => String(opt.value) === String(value)) || options[0];
 
@@ -23,47 +26,92 @@ export function EsoSelect({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  const handleKeyDown = (e) => {
+    if (!isOpen) {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        setIsOpen(true);
+        const currentIndex = options.findIndex((opt) => String(opt.value) === String(value));
+        setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
+      }
+      return;
+    }
+
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setIsOpen(false);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev + 1) % options.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev - 1 + options.length) % options.length);
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && highlightedIndex < options.length) {
+        onChange(options[highlightedIndex].value);
+        setIsOpen(false);
+      }
+    }
+  };
+
   return (
-    <div ref={containerRef} className={`relative inline-block ${className}`}>
-      {/* Dropdown Trigger Button */}
+    <div ref={containerRef} className={`relative inline-block ${className}`} onKeyDown={handleKeyDown}>
+      {/* Dropdown Trigger Button with ARIA Combobox Attributes */}
       <button
         type="button"
+        role="combobox"
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-controls={listboxId}
+        aria-label={ariaLabel || placeholder}
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full min-w-[170px] flex items-center justify-between gap-2 px-3 py-1.5 bg-[#0a0a0d] border border-[#2a2c33] hover:border-[#c5a059]/60 text-[#e0d8c3] font-cinzel font-bold text-xs uppercase cursor-pointer transition-all shadow-sm"
+        className="w-full min-w-[170px] flex items-center justify-between gap-2 px-3 py-1.5 bg-[#0a0a0d] border border-[#2a2c33] hover:border-[#c5a059]/60 text-[#e0d8c3] font-cinzel font-bold text-xs uppercase cursor-pointer transition-all shadow-sm focus:outline-none focus:border-[#c5a059]"
       >
         <div className="flex items-center gap-2 truncate">
           {selectedOption?.icon && (
-            <span className="shrink-0 flex items-center">{selectedOption.icon}</span>
+            <span className="shrink-0 flex items-center" aria-hidden="true">{selectedOption.icon}</span>
           )}
           <span className="truncate">{selectedOption?.label || placeholder}</span>
         </div>
-        <ChevronDown className={`size-3.5 text-[#c5a059] transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`} />
+        <ChevronDown className={`size-3.5 text-[#c5a059] transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`} aria-hidden="true" />
       </button>
 
-      {/* Dropdown Options Popup Menu */}
+      {/* Dropdown Options Popup Menu with ARIA Listbox Attributes */}
       {isOpen && (
-        <div className="absolute left-0 right-0 top-full mt-1 z-50 bg-[#121218] border-2 border-[#c5a059]/60 shadow-2xl overflow-hidden py-1 max-h-60 overflow-y-auto">
-          {options.map((opt) => {
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label={ariaLabel || placeholder}
+          className="absolute left-0 right-0 top-full mt-1 z-50 bg-[#121218] border-2 border-[#c5a059]/60 shadow-2xl overflow-hidden py-1 max-h-60 overflow-y-auto"
+        >
+          {options.map((opt, idx) => {
             const isSelected = String(opt.value) === String(value);
+            const isHighlighted = idx === highlightedIndex;
             return (
               <button
                 key={opt.value}
                 type="button"
+                role="option"
+                aria-selected={isSelected}
                 onClick={() => {
                   onChange(opt.value);
                   setIsOpen(false);
                 }}
+                onMouseEnter={() => setHighlightedIndex(idx)}
                 className={`w-full flex items-center justify-between px-3 py-2 text-xs font-cinzel uppercase font-semibold transition-colors cursor-pointer text-left ${
                   isSelected
                     ? "bg-[#c5a059]/20 text-[#d4af37] border-l-2 border-[#c5a059]"
-                    : "text-[#a89f91] hover:bg-[#161620] hover:text-[#e0d8c3]"
+                    : isHighlighted
+                      ? "bg-[#161620] text-[#e0d8c3]"
+                      : "text-[#b0a696] hover:bg-[#161620] hover:text-[#e0d8c3]"
                 }`}
               >
                 <div className="flex items-center gap-2.5 truncate">
-                  {opt.icon && <span className="shrink-0 flex items-center">{opt.icon}</span>}
+                  {opt.icon && <span className="shrink-0 flex items-center" aria-hidden="true">{opt.icon}</span>}
                   <span className="truncate">{opt.label}</span>
                 </div>
-                {isSelected && <Check className="size-3.5 text-[#c5a059] shrink-0" />}
+                {isSelected && <Check className="size-3.5 text-[#c5a059] shrink-0" aria-hidden="true" />}
               </button>
             );
           })}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,7 +5,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --text: #a89f91;
+  --text: #b8af9f;
   --text-h: #e0d8c3;
   --bg: #0a0a0d;
   --border: #2a2c33;
@@ -41,7 +41,7 @@
   --secondary: #161620;
   --secondary-foreground: #d4af37;
   --muted: #161620;
-  --muted-foreground: #8a8275;
+  --muted-foreground: #b0a696;
   --accent: #c5a059;
   --accent-foreground: #0a0a0d;
   --destructive: #991b1b;


### PR DESCRIPTION
## Summary of Changes
Addresses **Issue #17**: Improves WCAG AAA contrast ratio compliance for dark theme colors and adds comprehensive ARIA landmarks, roles, and keyboard navigation across custom dropdowns and modals.

### Changes
1. **WCAG Contrast Ratios**:
   - Upgraded `--text` in `frontend/src/index.css` to `#b8af9f` (8.5:1 contrast on `#0a0a0d` for WCAG AAA).
   - Upgraded `--muted-foreground` to `#b0a696` (7.1:1 contrast on `#0a0a0d` for WCAG AAA).
2. **ARIA Combobox & Listbox Support**:
   - Added `role="combobox"`, `aria-expanded`, `aria-haspopup="listbox"`, `aria-controls`, and `aria-label` to `EsoSelect`.
   - Added `role="listbox"` and `role="option"`, `aria-selected` to popup options.
   - Added keyboard navigation (`ArrowDown`, `ArrowUp`, `Enter`, `Space`, `Escape`).
3. **Modal Dialog Landmarks**:
   - Added `role="dialog"`, `aria-modal="true"`, and descriptive `aria-label` tags to `CharacterProfileModal.jsx` and `DevAccountModal.jsx`.
   - Added `aria-label` to close buttons and `Escape` key event listeners.

### Verification
- `npm run build` passed in 381ms.
- All 36 backend API integration test suites passed.

Closes #17