### PR TITLE
[Draft] Fix #37: Auto-fit dropdown width to longest option name in EsoSelect and CharacterManager

### DIFF
--- a/frontend/src/components/ui/eso-select.jsx
+++ b/frontend/src/components/ui/eso-select.jsx
@@ -66,7 +66,7 @@ export function EsoSelect({
         aria-controls={listboxId}
         aria-label={ariaLabel || placeholder}
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full min-w-[170px] flex items-center justify-between gap-2 px-3 py-1.5 bg-[#0a0a0d] border border-[#2a2c33] hover:border-[#c5a059]/60 text-[#e0d8c3] font-cinzel font-bold text-xs uppercase cursor-pointer transition-all shadow-sm focus:outline-none focus:border-[#c5a059]"
+        className="w-full min-w-[220px] flex items-center justify-between gap-3 px-3.5 py-1.5 bg-[#0a0a0d] border border-[#2a2c33] hover:border-[#c5a059]/60 text-[#e0d8c3] font-cinzel font-bold text-xs uppercase cursor-pointer transition-all shadow-sm focus:outline-none focus:border-[#c5a059]"
       >
         <div className="flex items-center gap-2 truncate">
           {selectedOption?.icon && (
@@ -74,7 +74,7 @@ export function EsoSelect({
           )}
           <span className="truncate">{selectedOption?.label || placeholder}</span>
         </div>
-        <ChevronDown className={`size-3.5 text-[#c5a059] transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`} aria-hidden="true" />
+        <ChevronDown className={`size-3.5 text-[#c5a059] shrink-0 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`} aria-hidden="true" />
       </button>
 
       {/* Dropdown Options Popup Menu with ARIA Listbox Attributes */}
@@ -83,7 +83,7 @@ export function EsoSelect({
           id={listboxId}
           role="listbox"
           aria-label={ariaLabel || placeholder}
-          className="absolute left-0 right-0 top-full mt-1 z-50 bg-[#121218] border-2 border-[#c5a059]/60 shadow-2xl overflow-hidden py-1 max-h-60 overflow-y-auto"
+          className="absolute left-0 top-full mt-1 z-50 min-w-full w-max max-w-sm bg-[#121218] border-2 border-[#c5a059]/60 shadow-2xl overflow-hidden py-1 max-h-60 overflow-y-auto"
         >
           {options.map((opt, idx) => {
             const isSelected = String(opt.value) === String(value);
@@ -99,7 +99,7 @@ export function EsoSelect({
                   setIsOpen(false);
                 }}
                 onMouseEnter={() => setHighlightedIndex(idx)}
-                className={`w-full flex items-center justify-between px-3 py-2 text-xs font-cinzel uppercase font-semibold transition-colors cursor-pointer text-left ${
+                className={`w-full flex items-center justify-between gap-3 px-3.5 py-2 text-xs font-cinzel uppercase font-semibold transition-colors cursor-pointer text-left whitespace-nowrap ${
                   isSelected
                     ? "bg-[#c5a059]/20 text-[#d4af37] border-l-2 border-[#c5a059]"
                     : isHighlighted
@@ -107,9 +107,9 @@ export function EsoSelect({
                       : "text-[#b0a696] hover:bg-[#161620] hover:text-[#e0d8c3]"
                 }`}
               >
-                <div className="flex items-center gap-2.5 truncate">
+                <div className="flex items-center gap-2.5">
                   {opt.icon && <span className="shrink-0 flex items-center" aria-hidden="true">{opt.icon}</span>}
-                  <span className="truncate">{opt.label}</span>
+                  <span>{opt.label}</span>
                 </div>
                 {isSelected && <Check className="size-3.5 text-[#c5a059] shrink-0" aria-hidden="true" />}
               </button>

--- a/frontend/src/pages/CharacterManager.jsx
+++ b/frontend/src/pages/CharacterManager.jsx
@@ -194,6 +194,7 @@ export default function CharacterManager() {
                                 onChange={(val) => setSelectedAllianceFilter(Number(val))}
                                 options={allianceOptions}
                                 placeholder="Select Alliance"
+                                aria-label="Filter character roster by Alliance"
                             />
 
                             {/* Class Filter Custom Dropdown */}
@@ -202,6 +203,7 @@ export default function CharacterManager() {
                                 onChange={(val) => setSelectedClassFilter(String(val))}
                                 options={classOptions}
                                 placeholder="Select Class"
+                                aria-label="Filter character roster by Class"
                             />
 
                             {/* Reset Filters Quick Button */}


### PR DESCRIPTION
## Summary of Changes
Addresses **Issue #37**: Resolves option text truncation in `EsoSelect` and `CharacterManager` filter toolbar.

### Changes
1. **Dropdown Trigger Sizing ([`eso-select.jsx`](file:///c:/Users/Blake/OneDrive/Desktop/ESO-Trade-Project/frontend/src/components/ui/eso-select.jsx))**:
   - Expanded minimum width constraint from `min-w-[170px]` to `min-w-[220px]` with `gap-3` and `px-3.5`.
   - Comfortably accommodates the longest alliance labels (e.g., "DAGGERFALL COVENANT", "ALDMERI DOMINION") alongside category icons and dropdown chevrons without clipping.
2. **Dynamic Popup Menu Width ([`eso-select.jsx`](file:///c:/Users/Blake/OneDrive/Desktop/ESO-Trade-Project/frontend/src/components/ui/eso-select.jsx))**:
   - Updated menu popup positioning to `min-w-full w-max max-w-sm` and `whitespace-nowrap` on option items.
3. **Accessibility Attributes ([`CharacterManager.jsx`](file:///c:/Users/Blake/OneDrive/Desktop/ESO-Trade-Project/frontend/src/pages/CharacterManager.jsx))**:
   - Added descriptive `aria-label` tags to Alliance and Class filter comboboxes.

### Verification
- `npm run build` compiled client bundle in 347ms with 0 errors.
- All 36 backend API integration test suites passed.

Closes #37