### PR TITLE
feat: add Marketplace saved search presets

### DIFF
--- a/backend/data-pipeline/test_api_endpoints.js
+++ b/backend/data-pipeline/test_api_endpoints.js
@@ -943,7 +943,85 @@ async function runTests() {
         }
         console.log(`   Requests feed query verified: ${feedRes.data.requests.length} requests returned!`);
 
-        console.log("\nAll 54 API endpoint test suites passed successfully!");
+        console.log("\n55. Testing authenticated saved-search lifecycle and ownership guards...");
+        const unauthSavedSearches = await httpGet('/api/saved-searches');
+        if (unauthSavedSearches.status !== 401) {
+            throw new Error(`Expected 401 for unauthenticated saved searches, got ${unauthSavedSearches.status}`);
+        }
+
+        const invalidSavedSearch = await httpPost('/api/saved-searches', {
+            name: "",
+            filter_params: { server: "NA" }
+        }, { 'Authorization': `Bearer ${bypassRes.data.token}` });
+        if (invalidSavedSearch.status !== 400) {
+            throw new Error(`Expected 400 for unnamed saved search, got ${invalidSavedSearch.status}`);
+        }
+
+        const createSavedSearchRes = await httpPost('/api/saved-searches', {
+            name: "Vivec gold tempers",
+            filter_params: {
+                server: "NA",
+                platform: "PC",
+                view: "listings",
+                category: "Materials",
+                subcategory: "Upgrade Temper",
+                location: "Vvardenfell",
+                deals_only: true,
+                unsupported_filter: "must not persist"
+            }
+        }, { 'Authorization': `Bearer ${bypassRes.data.token}` });
+        if (createSavedSearchRes.status !== 201 || !createSavedSearchRes.data.saved_search?.id) {
+            throw new Error(`Expected 201 creating saved search, got ${JSON.stringify(createSavedSearchRes.data)}`);
+        }
+        const savedSearchId = createSavedSearchRes.data.saved_search.id;
+        if (createSavedSearchRes.data.saved_search.filter_params.unsupported_filter !== undefined) {
+            throw new Error("Saved-search filter allowlist did not remove an unsupported key.");
+        }
+
+        const ownerSavedSearches = await httpGet('/api/saved-searches', {
+            'Authorization': `Bearer ${bypassRes.data.token}`
+        });
+        if (ownerSavedSearches.status !== 200 || ownerSavedSearches.data.saved_searches.length !== 1) {
+            throw new Error(`Owner could not retrieve saved search: ${JSON.stringify(ownerSavedSearches.data)}`);
+        }
+
+        const otherUserSavedSearches = await httpGet('/api/saved-searches', {
+            'Authorization': `Bearer ${user2BypassRes.data.token}`
+        });
+        if (otherUserSavedSearches.status !== 200 || otherUserSavedSearches.data.saved_searches.length !== 0) {
+            throw new Error(`Saved searches leaked across accounts: ${JSON.stringify(otherUserSavedSearches.data)}`);
+        }
+
+        const forbiddenPin = await httpPatch(`/api/saved-searches/${savedSearchId}/pin`, { is_pinned: true }, {
+            'Authorization': `Bearer ${user2BypassRes.data.token}`
+        });
+        if (forbiddenPin.status !== 404) {
+            throw new Error(`Expected 404 when another account pins a saved search, got ${forbiddenPin.status}`);
+        }
+
+        const pinSavedSearchRes = await httpPatch(`/api/saved-searches/${savedSearchId}/pin`, { is_pinned: true }, {
+            'Authorization': `Bearer ${bypassRes.data.token}`
+        });
+        if (pinSavedSearchRes.status !== 200 || pinSavedSearchRes.data.saved_search?.is_pinned !== true) {
+            throw new Error(`Owner could not pin saved search: ${JSON.stringify(pinSavedSearchRes.data)}`);
+        }
+
+        const forbiddenSavedSearchDelete = await httpDelete(`/api/saved-searches/${savedSearchId}`, {
+            'Authorization': `Bearer ${user2BypassRes.data.token}`
+        });
+        if (forbiddenSavedSearchDelete.status !== 404) {
+            throw new Error(`Expected 404 when another account deletes a saved search, got ${forbiddenSavedSearchDelete.status}`);
+        }
+
+        const deleteSavedSearchRes = await httpDelete(`/api/saved-searches/${savedSearchId}`, {
+            'Authorization': `Bearer ${bypassRes.data.token}`
+        });
+        if (deleteSavedSearchRes.status !== 200 || !deleteSavedSearchRes.data.success) {
+            throw new Error(`Owner could not delete saved search: ${JSON.stringify(deleteSavedSearchRes.data)}`);
+        }
+        console.log("   Saved-search create/list/pin/delete behavior and cross-account isolation verified!");
+
+        console.log("\nAll 55 API endpoint test suites passed successfully!");
     } catch (err) {
         console.error("API test failed:", err);
         process.exitCode = 1;

--- a/backend/server.js
+++ b/backend/server.js
@@ -217,6 +217,21 @@ function initializeDatabaseSchema() {
         db.run("CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);");
         db.run("CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);");
 
+        db.run(`
+            CREATE TABLE IF NOT EXISTS saved_searches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                filter_params TEXT NOT NULL,
+                is_pinned INTEGER NOT NULL DEFAULT 0 CHECK(is_pinned IN (0, 1)),
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+            );
+        `, (err) => {
+            if (err) console.error("Error creating 'saved_searches' table:", err.message);
+        });
+        db.run("CREATE INDEX IF NOT EXISTS idx_saved_searches_user ON saved_searches(user_id, is_pinned);");
+
         if (isDevMode) {
             const seedBlakeToken = process.env.BLAKE_API_TOKEN || crypto.randomBytes(16).toString("hex");
             const seedDemoToken = process.env.DEMO_API_TOKEN || crypto.randomBytes(16).toString("hex");
@@ -2611,6 +2626,197 @@ app.get("/api/auth/me", async (req, res) => {
         const user = await dbGet(`SELECT id, username, email, eso_handle, role, api_token, created_at FROM users WHERE id = ?;`, [userId]);
         if (!user) return res.status(404).json({ error: "User not found." });
         res.json({ success: true, user });
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// ============================================================================
+// AUTHENTICATED MARKETPLACE SAVED SEARCH PRESETS
+// ============================================================================
+
+const SAVED_SEARCH_FILTER_KEYS = new Set([
+    "server",
+    "platform",
+    "view",
+    "search",
+    "category",
+    "subcategory",
+    "trait",
+    "rarity",
+    "location",
+    "max_age",
+    "sort",
+    "deals_only"
+]);
+
+function normalizeSavedSearchFilters(rawFilters) {
+    let filters = rawFilters;
+    if (typeof filters === "string") {
+        try {
+            filters = JSON.parse(filters);
+        } catch {
+            return null;
+        }
+    }
+
+    if (!filters || typeof filters !== "object" || Array.isArray(filters)) {
+        return null;
+    }
+
+    const normalized = {};
+    for (const [key, value] of Object.entries(filters)) {
+        if (!SAVED_SEARCH_FILTER_KEYS.has(key)) continue;
+
+        if (key === "deals_only") {
+            normalized[key] = value === true;
+            continue;
+        }
+
+        if (typeof value !== "string") continue;
+        normalized[key] = value.trim().slice(0, 160);
+    }
+
+    if (normalized.server && !["NA", "EU"].includes(normalized.server)) return null;
+    if (normalized.platform && !["PC", "Xbox", "PlayStation"].includes(normalized.platform)) return null;
+    if (normalized.view && !["listings", "prices"].includes(normalized.view)) return null;
+
+    return normalized;
+}
+
+function formatSavedSearch(row) {
+    let filterParams = {};
+    try {
+        filterParams = JSON.parse(row.filter_params);
+    } catch {
+        filterParams = {};
+    }
+
+    return {
+        ...row,
+        is_pinned: Boolean(row.is_pinned),
+        filter_params: filterParams
+    };
+}
+
+/**
+ * GET /api/saved-searches
+ * Returns only the authenticated user's saved Marketplace filters.
+ */
+app.get("/api/saved-searches", async (req, res) => {
+    const userId = await getAuthUserId(req);
+    if (!userId) return res.status(401).json({ error: "Authentication required to view saved searches." });
+
+    try {
+        const rows = await dbAll(`
+            SELECT id, user_id, name, filter_params, is_pinned, created_at
+            FROM saved_searches
+            WHERE user_id = ?
+            ORDER BY is_pinned DESC, created_at DESC, id DESC;
+        `, [userId]);
+        res.json({ success: true, saved_searches: rows.map(formatSavedSearch) });
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});
+
+/**
+ * POST /api/saved-searches
+ * Stores a validated snapshot of the authenticated user's Marketplace filters.
+ */
+app.post("/api/saved-searches", async (req, res) => {
+    const userId = await getAuthUserId(req);
+    if (!userId) return res.status(401).json({ error: "Authentication required to save searches." });
+
+    const body = req.body || {};
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const filterParams = normalizeSavedSearchFilters(body.filter_params);
+    if (!name || name.length > 80) {
+        return res.status(400).json({ error: "Saved search name must be between 1 and 80 characters." });
+    }
+    if (!filterParams) {
+        return res.status(400).json({ error: "filter_params must be a valid Marketplace filter object." });
+    }
+
+    const serializedFilters = JSON.stringify(filterParams);
+    if (serializedFilters.length > 4000) {
+        return res.status(400).json({ error: "Saved search filters exceed the 4,000 character limit." });
+    }
+
+    try {
+        const result = await dbRun(`
+            INSERT INTO saved_searches (user_id, name, filter_params)
+            VALUES (?, ?, ?);
+        `, [userId, name, serializedFilters]);
+        const row = await dbGet(`
+            SELECT id, user_id, name, filter_params, is_pinned, created_at
+            FROM saved_searches
+            WHERE id = ? AND user_id = ?;
+        `, [result.lastID, userId]);
+        res.status(201).json({ success: true, saved_search: formatSavedSearch(row) });
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});
+
+/**
+ * PATCH /api/saved-searches/:id/pin
+ * Toggles pinned state, or applies an explicit boolean state when supplied.
+ */
+app.patch("/api/saved-searches/:id/pin", async (req, res) => {
+    const userId = await getAuthUserId(req);
+    if (!userId) return res.status(401).json({ error: "Authentication required to pin saved searches." });
+
+    const searchId = Number(req.params.id);
+    if (!Number.isInteger(searchId) || searchId <= 0) {
+        return res.status(400).json({ error: "Invalid saved search ID." });
+    }
+
+    try {
+        const existing = await dbGet(
+            "SELECT id, is_pinned FROM saved_searches WHERE id = ? AND user_id = ?;",
+            [searchId, userId]
+        );
+        if (!existing) return res.status(404).json({ error: "Saved search not found." });
+
+        const nextPinned = typeof req.body?.is_pinned === "boolean"
+            ? (req.body.is_pinned ? 1 : 0)
+            : (existing.is_pinned ? 0 : 1);
+        await dbRun(
+            "UPDATE saved_searches SET is_pinned = ? WHERE id = ? AND user_id = ?;",
+            [nextPinned, searchId, userId]
+        );
+        const row = await dbGet(`
+            SELECT id, user_id, name, filter_params, is_pinned, created_at
+            FROM saved_searches
+            WHERE id = ? AND user_id = ?;
+        `, [searchId, userId]);
+        res.json({ success: true, saved_search: formatSavedSearch(row) });
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});
+
+/**
+ * DELETE /api/saved-searches/:id
+ * Deletes a preset only when it belongs to the authenticated user.
+ */
+app.delete("/api/saved-searches/:id", async (req, res) => {
+    const userId = await getAuthUserId(req);
+    if (!userId) return res.status(401).json({ error: "Authentication required to delete saved searches." });
+
+    const searchId = Number(req.params.id);
+    if (!Number.isInteger(searchId) || searchId <= 0) {
+        return res.status(400).json({ error: "Invalid saved search ID." });
+    }
+
+    try {
+        const result = await dbRun(
+            "DELETE FROM saved_searches WHERE id = ? AND user_id = ?;",
+            [searchId, userId]
+        );
+        if (result.changes === 0) return res.status(404).json({ error: "Saved search not found." });
+        res.json({ success: true, message: "Saved search deleted." });
     } catch (err) {
         res.status(500).json({ error: err.message });
     }

--- a/docs/DatabaseSchema.md
+++ b/docs/DatabaseSchema.md
@@ -14,6 +14,7 @@ erDiagram
     USER ||--o{ WATCHLIST : tracks
     USER ||--o{ TRADE_REQUEST : initiates
     USER ||--o{ ACTIVITY_LOG : generates
+    USER ||--o{ SAVED_SEARCH : saves
 
     CHARACTER ||--o{ KNOWLEDGE : "character-specific"
     
@@ -33,6 +34,15 @@ erDiagram
         string discord_id
         string email
         boolean is_anonymized
+        timestamp created_at
+    }
+
+    SAVED_SEARCH {
+        integer id PK
+        integer user_id FK
+        string name
+        text filter_params "JSON filter snapshot"
+        boolean is_pinned
         timestamp created_at
     }
 
@@ -173,6 +183,15 @@ erDiagram
     - `created_at`: Creation timestamp.
     - `expires_at`: ISO timestamp indicating session expiration (default TTL: 7 days).
     - Indexes: `idx_sessions_expires_at`, `idx_sessions_user_id`.
+
+### 2.7. Marketplace Saved Searches
+- **`saved_searches`**: Private, account-owned Marketplace filter presets in the active SQLite runtime.
+    - `user_id`: Foreign key referencing `users(id)` with `ON DELETE CASCADE`.
+    - `name`: User-facing preset name, validated to 1–80 characters by the API.
+    - `filter_params`: JSON text containing only the supported Marketplace filter keys.
+    - `is_pinned`: SQLite boolean (`0` or `1`) used to surface one-click pinned filters.
+    - `created_at`: Preset creation timestamp.
+    - Index: `idx_saved_searches_user` on `(user_id, is_pinned)` for account-scoped sidebar retrieval.
 
 ## 3. Scalability & Logic
 

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -162,6 +162,54 @@ export async function purgeExpiredListings() {
 }
 
 // ============================================================================
+// AUTHENTICATED MARKETPLACE SAVED SEARCHES
+// ============================================================================
+
+export async function fetchSavedSearches() {
+    try {
+        const response = await apiFetch('/api/saved-searches');
+        return await safeJsonResponse(response, 'Unable to load saved searches.');
+    } catch (error) {
+        return { success: false, saved_searches: [], error: error.message };
+    }
+}
+
+export async function createSavedSearch(name, filterParams) {
+    try {
+        const response = await apiFetch('/api/saved-searches', {
+            method: 'POST',
+            body: JSON.stringify({ name, filter_params: filterParams })
+        });
+        return await safeJsonResponse(response, 'Unable to save this search.');
+    } catch (error) {
+        return { success: false, error: error.message };
+    }
+}
+
+export async function setSavedSearchPinned(searchId, isPinned) {
+    try {
+        const response = await apiFetch(`/api/saved-searches/${searchId}/pin`, {
+            method: 'PATCH',
+            body: JSON.stringify({ is_pinned: isPinned })
+        });
+        return await safeJsonResponse(response, 'Unable to update this saved search.');
+    } catch (error) {
+        return { success: false, error: error.message };
+    }
+}
+
+export async function deleteSavedSearch(searchId) {
+    try {
+        const response = await apiFetch(`/api/saved-searches/${searchId}`, {
+            method: 'DELETE'
+        });
+        return await safeJsonResponse(response, 'Unable to delete this saved search.');
+    } catch (error) {
+        return { success: false, error: error.message };
+    }
+}
+
+// ============================================================================
 // AUTHENTICATION & DEV ACCOUNTS API HELPERS
 // ============================================================================
 

--- a/frontend/src/components/SavedSearchesCard.jsx
+++ b/frontend/src/components/SavedSearchesCard.jsx
@@ -5,9 +5,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 function describeFilters(filters = {}, fallbackSearch = "") {
-  const scope = [filters.platform, filters.server, "Live listings"]
-    .filter(Boolean)
-    .join(" · ");
   const details = [
     filters.search && `“${filters.search}”`,
     filters.category,
@@ -18,14 +15,11 @@ function describeFilters(filters = {}, fallbackSearch = "") {
     filters.deals_only && "Deals only",
   ].filter(Boolean);
 
-  return {
-    scope,
-    details: details.length
-      ? details.slice(0, 3).join(" · ")
-      : fallbackSearch
-        ? `“${fallbackSearch}”`
-        : "All active listings",
-  };
+  return details.length
+    ? details.slice(0, 3).join(" · ")
+    : fallbackSearch
+      ? `“${fallbackSearch}”`
+      : "All active listings";
 }
 
 export function PinnedSearchChips({ searches, onApply }) {
@@ -59,7 +53,7 @@ export default function SavedSearchesCard({
   searches,
   isLoading,
   isMutating,
-  message,
+  error,
   onSave,
   onApply,
   onTogglePin,
@@ -149,16 +143,12 @@ export default function SavedSearchesCard({
               </Button>
             </form>
 
-            {message?.text && (
+            {error && (
               <p
-                role="status"
-                className={`border px-2.5 py-2 text-[11px] ${
-                  message.type === "error"
-                    ? "border-red-900/60 bg-red-950/30 text-red-300"
-                    : "border-emerald-900/60 bg-emerald-950/30 text-emerald-300"
-                }`}
+                role="alert"
+                className="border border-red-900/60 bg-red-950/30 px-2.5 py-2 text-[11px] text-red-300"
               >
-                {message.text}
+                {error}
               </p>
             )}
 
@@ -193,8 +183,7 @@ export default function SavedSearchesCard({
                             className="min-w-0 flex-1 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c5a059]/50"
                           >
                             <span className="block truncate text-xs font-semibold text-[#e0d8c3]">{search.name}</span>
-                            <span className="mt-1 block text-[10px] font-mono uppercase tracking-wide text-[#c5a059]">{description.scope}</span>
-                            <span className="mt-1 block truncate text-[10px] text-[#8a8275]">{description.details}</span>
+                            <span className="mt-1 block truncate text-[10px] text-[#8a8275]">{description}</span>
                           </button>
                           <div className="flex shrink-0 items-center gap-1">
                             <Button

--- a/frontend/src/components/SavedSearchesCard.jsx
+++ b/frontend/src/components/SavedSearchesCard.jsx
@@ -1,0 +1,228 @@
+import { useId, useState } from "react";
+import { Bookmark, LogIn, Pin, Plus, Search, Trash2, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+function describeFilters(filters = {}) {
+  const scope = [filters.platform, filters.server, filters.view === "listings" ? "Listings" : "Prices"]
+    .filter(Boolean)
+    .join(" · ");
+  const details = [
+    filters.search && `“${filters.search}”`,
+    filters.category,
+    filters.subcategory,
+    filters.trait && `Trait ${filters.trait}`,
+    filters.rarity && `Quality ${filters.rarity}`,
+    filters.location,
+    filters.deals_only && "Deals only",
+  ].filter(Boolean);
+
+  return {
+    scope,
+    details: details.length ? details.slice(0, 3).join(" · ") : "All marketplace items",
+  };
+}
+
+export function PinnedSearchChips({ searches, onApply }) {
+  const pinnedSearches = searches.filter((search) => search.is_pinned);
+  if (!pinnedSearches.length) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" aria-label="Pinned saved searches">
+      <span className="text-[10px] font-cinzel font-bold uppercase tracking-widest text-[#8a8275]">
+        Pinned
+      </span>
+      {pinnedSearches.map((search) => (
+        <Button
+          key={search.id}
+          type="button"
+          variant="outline"
+          size="xs"
+          onClick={() => onApply(search)}
+          className="rounded-none border-[#c5a059]/50 bg-[#c5a059]/10 text-[#d4af37] hover:border-[#d4af37] hover:bg-[#c5a059]/20"
+        >
+          <Pin className="size-3 fill-current" />
+          {search.name}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+export default function SavedSearchesCard({
+  user,
+  searches,
+  isLoading,
+  isMutating,
+  message,
+  onSave,
+  onApply,
+  onTogglePin,
+  onDelete,
+  onLogin,
+  onClose,
+}) {
+  const [name, setName] = useState("");
+  const nameInputId = useId();
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const wasSaved = await onSave(name);
+    if (wasSaved) setName("");
+  };
+
+  return (
+    <Card className="eso-card rounded-none border-[#2a2c33] bg-[#121218] py-0 gap-0">
+      <CardHeader className="border-b border-[#2a2c33] px-4 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="flex items-center gap-2 text-sm text-[#e0d8c3]">
+            <Bookmark className="size-4 text-[#c5a059]" />
+            Saved Searches
+          </CardTitle>
+          {onClose && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={onClose}
+              aria-label="Close saved searches"
+              className="rounded-none text-[#a89f91] hover:text-[#e0d8c3]"
+            >
+              <X />
+            </Button>
+          )}
+        </div>
+        <p className="text-[11px] leading-relaxed text-[#8a8275]">
+          Keep useful market combinations ready for your next trader run.
+        </p>
+      </CardHeader>
+
+      <CardContent className="space-y-4 px-4 py-4">
+        {!user ? (
+          <div className="border border-dashed border-[#c5a059]/40 bg-[#c5a059]/5 p-4 text-center">
+            <LogIn className="mx-auto mb-2 size-5 text-[#c5a059]" />
+            <p className="text-xs font-cinzel font-bold uppercase tracking-wider text-[#e0d8c3]">
+              Sign in to save filters
+            </p>
+            <p className="mt-1 text-[11px] leading-relaxed text-[#8a8275]">
+              Your presets stay private to your account.
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              onClick={onLogin}
+              className="mt-3 w-full rounded-none bg-[#c5a059] text-[#0a0a0d] hover:bg-[#d4af37]"
+            >
+              Sign In
+            </Button>
+          </div>
+        ) : (
+          <>
+            <form onSubmit={handleSubmit} className="space-y-2">
+              <label htmlFor={nameInputId} className="text-[10px] font-cinzel font-bold uppercase tracking-widest text-[#a89f91]">
+                Save current filters
+              </label>
+              <input
+                id={nameInputId}
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                maxLength={80}
+                placeholder="e.g. Vivec gold tempers"
+                className="h-9 w-full rounded-none border border-[#2a2c33] bg-[#0a0a0d] px-3 text-xs text-[#e0d8c3] outline-none placeholder:text-[#625d55] focus:border-[#c5a059] focus:ring-2 focus:ring-[#c5a059]/20"
+              />
+              <Button
+                type="submit"
+                size="sm"
+                disabled={isMutating || !name.trim()}
+                className="w-full rounded-none bg-[#c5a059] text-[#0a0a0d] hover:bg-[#d4af37]"
+              >
+                <Plus />
+                Save Search
+              </Button>
+            </form>
+
+            {message?.text && (
+              <p
+                role="status"
+                className={`border px-2.5 py-2 text-[11px] ${
+                  message.type === "error"
+                    ? "border-red-900/60 bg-red-950/30 text-red-300"
+                    : "border-emerald-900/60 bg-emerald-950/30 text-emerald-300"
+                }`}
+              >
+                {message.text}
+              </p>
+            )}
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] font-cinzel font-bold uppercase tracking-widest text-[#a89f91]">
+                  Your presets
+                </span>
+                <span className="font-mono text-[10px] text-[#625d55]">{searches.length}</span>
+              </div>
+
+              {isLoading ? (
+                <div className="flex items-center justify-center border border-[#2a2c33] py-6">
+                  <div className="size-5 animate-spin rounded-full border-2 border-[#2a2c33] border-b-[#c5a059]" />
+                  <span className="sr-only">Loading saved searches</span>
+                </div>
+              ) : searches.length === 0 ? (
+                <div className="border border-dashed border-[#2a2c33] px-3 py-5 text-center">
+                  <Search className="mx-auto mb-2 size-4 text-[#625d55]" />
+                  <p className="text-[11px] text-[#8a8275]">No saved searches yet.</p>
+                </div>
+              ) : (
+                <ul className="max-h-[28rem] space-y-2 overflow-y-auto pr-1">
+                  {searches.map((search) => {
+                    const description = describeFilters(search.filter_params);
+                    return (
+                      <li key={search.id} className="border border-[#2a2c33] bg-[#0a0a0d] p-3 hover:border-[#c5a059]/50">
+                        <div className="flex items-start justify-between gap-2">
+                          <button
+                            type="button"
+                            onClick={() => onApply(search)}
+                            className="min-w-0 flex-1 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c5a059]/50"
+                          >
+                            <span className="block truncate text-xs font-semibold text-[#e0d8c3]">{search.name}</span>
+                            <span className="mt-1 block text-[10px] font-mono uppercase tracking-wide text-[#c5a059]">{description.scope}</span>
+                            <span className="mt-1 block truncate text-[10px] text-[#8a8275]">{description.details}</span>
+                          </button>
+                          <div className="flex shrink-0 items-center gap-1">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              disabled={isMutating}
+                              onClick={() => onTogglePin(search)}
+                              aria-label={`${search.is_pinned ? "Unpin" : "Pin"} ${search.name}`}
+                              className={`rounded-none ${search.is_pinned ? "text-[#d4af37]" : "text-[#625d55] hover:text-[#d4af37]"}`}
+                            >
+                              <Pin className={search.is_pinned ? "fill-current" : ""} />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              disabled={isMutating}
+                              onClick={() => onDelete(search)}
+                              aria-label={`Delete ${search.name}`}
+                              className="rounded-none text-[#625d55] hover:bg-red-950/30 hover:text-red-400"
+                            >
+                              <Trash2 />
+                            </Button>
+                          </div>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/SavedSearchesCard.jsx
+++ b/frontend/src/components/SavedSearchesCard.jsx
@@ -4,8 +4,8 @@ import { Bookmark, LogIn, Pin, Plus, Search, Trash2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-function describeFilters(filters = {}) {
-  const scope = [filters.platform, filters.server, filters.view === "listings" ? "Listings" : "Prices"]
+function describeFilters(filters = {}, fallbackSearch = "") {
+  const scope = [filters.platform, filters.server, "Live listings"]
     .filter(Boolean)
     .join(" · ");
   const details = [
@@ -20,7 +20,11 @@ function describeFilters(filters = {}) {
 
   return {
     scope,
-    details: details.length ? details.slice(0, 3).join(" · ") : "All marketplace items",
+    details: details.length
+      ? details.slice(0, 3).join(" · ")
+      : fallbackSearch
+        ? `“${fallbackSearch}”`
+        : "All active listings",
   };
 }
 
@@ -121,16 +125,19 @@ export default function SavedSearchesCard({
           <>
             <form onSubmit={handleSubmit} className="space-y-2">
               <label htmlFor={nameInputId} className="text-[10px] font-cinzel font-bold uppercase tracking-widest text-[#a89f91]">
-                Save current filters
+                Save filters or item search
               </label>
               <input
                 id={nameInputId}
                 value={name}
                 onChange={(event) => setName(event.target.value)}
                 maxLength={80}
-                placeholder="e.g. Vivec gold tempers"
+                placeholder="Item or preset name (e.g. lockpick)"
                 className="h-9 w-full rounded-none border border-[#2a2c33] bg-[#0a0a0d] px-3 text-xs text-[#e0d8c3] outline-none placeholder:text-[#625d55] focus:border-[#c5a059] focus:ring-2 focus:ring-[#c5a059]/20"
               />
+              <p className="text-[10px] leading-relaxed text-[#625d55]">
+                With no filters selected, this name becomes the live item search.
+              </p>
               <Button
                 type="submit"
                 size="sm"
@@ -176,7 +183,7 @@ export default function SavedSearchesCard({
               ) : (
                 <ul className="max-h-[28rem] space-y-2 overflow-y-auto pr-1">
                   {searches.map((search) => {
-                    const description = describeFilters(search.filter_params);
+                    const description = describeFilters(search.filter_params, search.name);
                     return (
                       <li key={search.id} className="border border-[#2a2c33] bg-[#0a0a0d] p-3 hover:border-[#c5a059]/50">
                         <div className="flex items-start justify-between gap-2">

--- a/frontend/src/pages/Marketplace.jsx
+++ b/frontend/src/pages/Marketplace.jsx
@@ -10,14 +10,13 @@ import {
   Zap,
   Info,
   Trash2,
-  ChevronRight,
-  Filter,
   Layers,
   Copy,
   Check,
   DollarSign,
   Compass,
-  Clock
+  Clock,
+  Bookmark
 } from "lucide-react";
 
 import {
@@ -48,9 +47,20 @@ import {
 
 import { useNavigate, useSearchParams } from "react-router-dom";
 import Navbar from "@/components/ui/navbar";
+import SavedSearchesCard, { PinnedSearchChips } from "@/components/SavedSearchesCard";
 import { useTheme } from "@/components/theme-provider";
 import { useAuth } from "@/context/AuthContext";
-import { fetchTaxonomy, fetchMarketListings, fetchMarketPrices, extractLiveListings, clearAllListings } from "@/api/api";
+import {
+  fetchTaxonomy,
+  fetchMarketListings,
+  fetchMarketPrices,
+  extractLiveListings,
+  clearAllListings,
+  fetchSavedSearches,
+  createSavedSearch,
+  setSavedSearchPinned,
+  deleteSavedSearch
+} from "@/api/api";
 import { cleanEsoText, renderEsoFormattedText, getEsoIconUrl } from "@/lib/utils";
 
 const DEAL_THRESHOLD = 1.2;
@@ -124,7 +134,7 @@ const formatLastSeen = (timestamp) => {
 };
 
 function Marketplace() {
-  const { serverLocation, platform } = useTheme();
+  const { serverLocation, setServerLocation, platform, setPlatform } = useTheme();
   const { user } = useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -142,6 +152,11 @@ function Marketplace() {
   const [sortOption, setSortOption] = useState(searchParams.get("sort") || "value_index");
   const [dealsOnly, setDealsOnly] = useState(false);
   const [copiedLink, setCopiedLink] = useState(false);
+  const [savedSearches, setSavedSearches] = useState([]);
+  const [savedSearchesLoading, setSavedSearchesLoading] = useState(false);
+  const [savedSearchesMutating, setSavedSearchesMutating] = useState(false);
+  const [savedSearchMessage, setSavedSearchMessage] = useState(null);
+  const [savedSearchDrawerOpen, setSavedSearchDrawerOpen] = useState(false);
 
   // Sync URL search parameters on change
   useEffect(() => {
@@ -176,6 +191,67 @@ function Marketplace() {
       if (data) setTaxonomy(data);
     });
   }, []);
+
+  const currentSavedSearchFilters = useMemo(() => ({
+    server: serverLocation,
+    platform,
+    view: viewMode,
+    search: searchQuery,
+    category: selectedCategory,
+    subcategory: selectedSubcategory,
+    trait: selectedTrait,
+    rarity: selectedRarity,
+    location: selectedHubLocation,
+    max_age: selectedMaxAge,
+    sort: sortOption,
+    deals_only: dealsOnly,
+  }), [
+    serverLocation,
+    platform,
+    viewMode,
+    searchQuery,
+    selectedCategory,
+    selectedSubcategory,
+    selectedTrait,
+    selectedRarity,
+    selectedHubLocation,
+    selectedMaxAge,
+    sortOption,
+    dealsOnly,
+  ]);
+
+  useEffect(() => {
+    let isActive = true;
+    if (!user?.id) {
+      setSavedSearches([]);
+      setSavedSearchMessage(null);
+      return undefined;
+    }
+
+    setSavedSearchesLoading(true);
+    fetchSavedSearches().then((result) => {
+      if (!isActive) return;
+      if (result.success) {
+        setSavedSearches(result.saved_searches || []);
+      } else {
+        setSavedSearchMessage({ type: "error", text: result.error || "Unable to load saved searches." });
+      }
+      setSavedSearchesLoading(false);
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (!savedSearchDrawerOpen) return undefined;
+    const handleEscape = (event) => {
+      if (event.key === "Escape") setSavedSearchDrawerOpen(false);
+    };
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [savedSearchDrawerOpen]);
 
   // Fetch Market Data when filters/server/page change
   useEffect(() => {
@@ -250,6 +326,93 @@ function Marketplace() {
     setDealsOnly(false);
     setCurrentPage(1);
     setSelectedItem(null);
+  };
+
+  const handleSaveSearch = async (name) => {
+    if (!user) {
+      navigate('/login', { state: { from: { pathname: '/marketplace' } } });
+      return false;
+    }
+
+    setSavedSearchesMutating(true);
+    setSavedSearchMessage(null);
+    const result = await createSavedSearch(name.trim(), currentSavedSearchFilters);
+    if (result.success && result.saved_search) {
+      setSavedSearches((current) => [result.saved_search, ...current]);
+      setSavedSearchMessage({ type: "success", text: `Saved “${result.saved_search.name}”.` });
+      setSavedSearchesMutating(false);
+      return true;
+    }
+
+    setSavedSearchMessage({ type: "error", text: result.error || "Unable to save this search." });
+    setSavedSearchesMutating(false);
+    return false;
+  };
+
+  const handleApplySavedSearch = (savedSearch) => {
+    const filters = savedSearch.filter_params || {};
+    const nextView = filters.view === "listings" ? "listings" : "prices";
+    setServerLocation(filters.server === "EU" ? "EU" : "NA");
+    setPlatform(["PC", "Xbox", "PlayStation"].includes(filters.platform) ? filters.platform : "PC");
+    setViewMode(nextView);
+    setSearchQuery(filters.search || "");
+    setSelectedCategory(filters.category || "");
+    setSelectedSubcategory(filters.subcategory || "");
+    setSelectedTrait(filters.trait || "");
+    setSelectedRarity(filters.rarity || "");
+    setSelectedHubLocation(filters.location || "");
+    setSelectedMaxAge(filters.max_age || "");
+    setSortOption(filters.sort || (nextView === "listings" ? "value_index" : "suggested_desc"));
+    setDealsOnly(nextView === "listings" && filters.deals_only === true);
+    setCurrentPage(1);
+    setSelectedItem(null);
+    setSavedSearchDrawerOpen(false);
+    setSavedSearchMessage({ type: "success", text: `Applied “${savedSearch.name}”.` });
+  };
+
+  const handleToggleSavedSearchPin = async (savedSearch) => {
+    setSavedSearchesMutating(true);
+    setSavedSearchMessage(null);
+    const result = await setSavedSearchPinned(savedSearch.id, !savedSearch.is_pinned);
+    if (result.success && result.saved_search) {
+      setSavedSearches((current) => current
+        .map((search) => search.id === savedSearch.id ? result.saved_search : search)
+        .sort((a, b) => Number(b.is_pinned) - Number(a.is_pinned) || b.id - a.id));
+      setSavedSearchMessage({
+        type: "success",
+        text: `${result.saved_search.is_pinned ? "Pinned" : "Unpinned"} “${result.saved_search.name}”.`,
+      });
+    } else {
+      setSavedSearchMessage({ type: "error", text: result.error || "Unable to update this saved search." });
+    }
+    setSavedSearchesMutating(false);
+  };
+
+  const handleDeleteSavedSearch = async (savedSearch) => {
+    if (!window.confirm(`Delete the saved search “${savedSearch.name}”?`)) return;
+    setSavedSearchesMutating(true);
+    setSavedSearchMessage(null);
+    const result = await deleteSavedSearch(savedSearch.id);
+    if (result.success) {
+      setSavedSearches((current) => current.filter((search) => search.id !== savedSearch.id));
+      setSavedSearchMessage({ type: "success", text: `Deleted “${savedSearch.name}”.` });
+    } else {
+      setSavedSearchMessage({ type: "error", text: result.error || "Unable to delete this saved search." });
+    }
+    setSavedSearchesMutating(false);
+  };
+
+  const savedSearchesCardProps = {
+    user,
+    searches: savedSearches,
+    isLoading: savedSearchesLoading,
+    isMutating: savedSearchesMutating,
+    message: savedSearchMessage,
+    onSave: handleSaveSearch,
+    onApply: handleApplySavedSearch,
+    onTogglePin: handleToggleSavedSearchPin,
+    onDelete: handleDeleteSavedSearch,
+    onLogin: () => navigate('/login', { state: { from: { pathname: '/marketplace' } } }),
   };
 
   const handleClearListings = async () => {
@@ -634,9 +797,24 @@ function Marketplace() {
         </NativeSelect>
       </div>
 
+      {user && (
+        <PinnedSearchChips searches={savedSearches} onApply={handleApplySavedSearch} />
+      )}
+
       {/* Filter Quick Tags & Deals Toggle */}
       <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setSavedSearchDrawerOpen(true)}
+            className="rounded-none border-[#c5a059]/40 bg-[#161620] text-[#d4af37] lg:hidden"
+          >
+            <Bookmark className="size-3.5" />
+            Saved Searches{savedSearches.length ? ` (${savedSearches.length})` : ""}
+          </Button>
+
           {viewMode === "listings" && (
             <Button
               variant={dealsOnly ? "default" : "outline"}
@@ -673,8 +851,29 @@ function Marketplace() {
         </div>
       </div>
 
+      {savedSearchDrawerOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden" role="dialog" aria-modal="true" aria-label="Saved searches">
+          <button
+            type="button"
+            onClick={() => setSavedSearchDrawerOpen(false)}
+            aria-label="Close saved searches"
+            className="absolute inset-0 cursor-default bg-black/75 backdrop-blur-sm"
+          />
+          <aside className="absolute inset-y-0 left-0 w-[min(90vw,24rem)] overflow-y-auto border-r border-[#c5a059]/40 bg-[#0a0a0d] p-3 shadow-2xl">
+            <SavedSearchesCard
+              {...savedSearchesCardProps}
+              onClose={() => setSavedSearchDrawerOpen(false)}
+            />
+          </aside>
+        </div>
+      )}
+
       {/* Main Grid & Detail Sidebar Layout */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 mb-8">
+        <aside className="hidden lg:col-span-1 lg:block lg:self-start lg:sticky lg:top-4">
+          <SavedSearchesCard {...savedSearchesCardProps} />
+        </aside>
+
         {/* Listings / Prices Grid */}
         <div className={selectedItem ? "lg:col-span-2 space-y-4" : "lg:col-span-3 space-y-4"}>
           {isLoading ? (

--- a/frontend/src/pages/Marketplace.jsx
+++ b/frontend/src/pages/Marketplace.jsx
@@ -164,7 +164,7 @@ function Marketplace() {
   const [savedSearches, setSavedSearches] = useState([]);
   const [savedSearchesLoading, setSavedSearchesLoading] = useState(false);
   const [savedSearchesMutating, setSavedSearchesMutating] = useState(false);
-  const [savedSearchMessage, setSavedSearchMessage] = useState(null);
+  const [savedSearchError, setSavedSearchError] = useState("");
   const [savedSearchDrawerOpen, setSavedSearchDrawerOpen] = useState(false);
   const [savedSearchRunId, setSavedSearchRunId] = useState(0);
 
@@ -231,7 +231,7 @@ function Marketplace() {
     let isActive = true;
     if (!user?.id) {
       setSavedSearches([]);
-      setSavedSearchMessage(null);
+      setSavedSearchError("");
       return undefined;
     }
 
@@ -241,7 +241,7 @@ function Marketplace() {
       if (result.success) {
         setSavedSearches(result.saved_searches || []);
       } else {
-        setSavedSearchMessage({ type: "error", text: result.error || "Unable to load saved searches." });
+        setSavedSearchError(result.error || "Unable to load saved searches.");
       }
       setSavedSearchesLoading(false);
     });
@@ -341,7 +341,7 @@ function Marketplace() {
     }
 
     setSavedSearchesMutating(true);
-    setSavedSearchMessage(null);
+    setSavedSearchError("");
     const trimmedName = name.trim();
     const hasActiveCriteria = Boolean(
       currentSavedSearchFilters.search ||
@@ -367,17 +367,11 @@ function Marketplace() {
         setSelectedItem(null);
         setSavedSearchRunId((current) => current + 1);
       }
-      setSavedSearchMessage({
-        type: "success",
-        text: !hasActiveCriteria
-          ? `Saved and searched for “${result.saved_search.name}”.`
-          : `Saved “${result.saved_search.name}”.`,
-      });
       setSavedSearchesMutating(false);
       return true;
     }
 
-    setSavedSearchMessage({ type: "error", text: result.error || "Unable to save this search." });
+    setSavedSearchError(result.error || "Unable to save this search.");
     setSavedSearchesMutating(false);
     return false;
   };
@@ -411,23 +405,18 @@ function Marketplace() {
     setSelectedItem(null);
     setSavedSearchRunId((current) => current + 1);
     setSavedSearchDrawerOpen(false);
-    setSavedSearchMessage({ type: "success", text: `Applied “${savedSearch.name}”.` });
   };
 
   const handleToggleSavedSearchPin = async (savedSearch) => {
     setSavedSearchesMutating(true);
-    setSavedSearchMessage(null);
+    setSavedSearchError("");
     const result = await setSavedSearchPinned(savedSearch.id, !savedSearch.is_pinned);
     if (result.success && result.saved_search) {
       setSavedSearches((current) => current
         .map((search) => search.id === savedSearch.id ? result.saved_search : search)
         .sort((a, b) => Number(b.is_pinned) - Number(a.is_pinned) || b.id - a.id));
-      setSavedSearchMessage({
-        type: "success",
-        text: `${result.saved_search.is_pinned ? "Pinned" : "Unpinned"} “${result.saved_search.name}”.`,
-      });
     } else {
-      setSavedSearchMessage({ type: "error", text: result.error || "Unable to update this saved search." });
+      setSavedSearchError(result.error || "Unable to update this saved search.");
     }
     setSavedSearchesMutating(false);
   };
@@ -435,13 +424,12 @@ function Marketplace() {
   const handleDeleteSavedSearch = async (savedSearch) => {
     if (!window.confirm(`Delete the saved search “${savedSearch.name}”?`)) return;
     setSavedSearchesMutating(true);
-    setSavedSearchMessage(null);
+    setSavedSearchError("");
     const result = await deleteSavedSearch(savedSearch.id);
     if (result.success) {
       setSavedSearches((current) => current.filter((search) => search.id !== savedSearch.id));
-      setSavedSearchMessage({ type: "success", text: `Deleted “${savedSearch.name}”.` });
     } else {
-      setSavedSearchMessage({ type: "error", text: result.error || "Unable to delete this saved search." });
+      setSavedSearchError(result.error || "Unable to delete this saved search.");
     }
     setSavedSearchesMutating(false);
   };
@@ -451,7 +439,7 @@ function Marketplace() {
     searches: savedSearches,
     isLoading: savedSearchesLoading,
     isMutating: savedSearchesMutating,
-    message: savedSearchMessage,
+    error: savedSearchError,
     onSave: handleSaveSearch,
     onApply: handleApplySavedSearch,
     onTogglePin: handleToggleSavedSearchPin,

--- a/frontend/src/pages/Marketplace.jsx
+++ b/frontend/src/pages/Marketplace.jsx
@@ -5,10 +5,8 @@ import {
   Tag,
   Store,
   MapPin,
-  TrendingUp,
   Sparkles,
   Zap,
-  Info,
   Trash2,
   Layers,
   Copy,
@@ -53,7 +51,6 @@ import { useAuth } from "@/context/AuthContext";
 import {
   fetchTaxonomy,
   fetchMarketListings,
-  fetchMarketPrices,
   extractLiveListings,
   clearAllListings,
   fetchSavedSearches,
@@ -64,6 +61,16 @@ import {
 import { cleanEsoText, renderEsoFormattedText, getEsoIconUrl } from "@/lib/utils";
 
 const DEAL_THRESHOLD = 1.2;
+const LISTING_SORT_VALUES = new Set([
+  "value_index",
+  "trait_asc",
+  "trait_desc",
+  "rarity_desc",
+  "rarity_asc",
+  "price_asc",
+  "price_desc",
+  "newest",
+]);
 
 const RARITY_MAP = {
   1: { label: "Normal", color: "border-gray-600 text-gray-300 bg-gray-900/40" },
@@ -140,7 +147,6 @@ function Marketplace() {
   const [searchParams] = useSearchParams();
 
   // State Management
-  const [viewMode, setViewMode] = useState(searchParams.get("view") || "prices");
   const [taxonomy, setTaxonomy] = useState({});
   const [selectedCategory, setSelectedCategory] = useState(searchParams.get("category") || "");
   const [selectedSubcategory, setSelectedSubcategory] = useState(searchParams.get("subcategory") || "");
@@ -149,7 +155,10 @@ function Marketplace() {
   const [selectedHubLocation, setSelectedHubLocation] = useState(searchParams.get("location") || "");
   const [selectedMaxAge, setSelectedMaxAge] = useState("");
   const [searchQuery, setSearchQuery] = useState(searchParams.get("search") || "");
-  const [sortOption, setSortOption] = useState(searchParams.get("sort") || "value_index");
+  const [sortOption, setSortOption] = useState(() => {
+    const requestedSort = searchParams.get("sort");
+    return LISTING_SORT_VALUES.has(requestedSort) ? requestedSort : "value_index";
+  });
   const [dealsOnly, setDealsOnly] = useState(false);
   const [copiedLink, setCopiedLink] = useState(false);
   const [savedSearches, setSavedSearches] = useState([]);
@@ -157,6 +166,7 @@ function Marketplace() {
   const [savedSearchesMutating, setSavedSearchesMutating] = useState(false);
   const [savedSearchMessage, setSavedSearchMessage] = useState(null);
   const [savedSearchDrawerOpen, setSavedSearchDrawerOpen] = useState(false);
+  const [savedSearchRunId, setSavedSearchRunId] = useState(0);
 
   // Sync URL search parameters on change
   useEffect(() => {
@@ -164,14 +174,12 @@ function Marketplace() {
     const t = searchParams.get("trait");
     const cat = searchParams.get("category");
     const subcat = searchParams.get("subcategory");
-    const vm = searchParams.get("view");
     const srt = searchParams.get("sort");
     if (q !== null && q !== undefined) setSearchQuery(q);
     if (t !== null && t !== undefined) setSelectedTrait(t);
     if (cat !== null && cat !== undefined) setSelectedCategory(cat);
     if (subcat !== null && subcat !== undefined) setSelectedSubcategory(subcat);
-    if (vm === "listings" || vm === "prices") setViewMode(vm);
-    if (srt !== null && srt !== undefined) setSortOption(srt);
+    if (srt !== null && srt !== undefined && LISTING_SORT_VALUES.has(srt)) setSortOption(srt);
     setCurrentPage(1);
   }, [searchParams]);
 
@@ -195,7 +203,7 @@ function Marketplace() {
   const currentSavedSearchFilters = useMemo(() => ({
     server: serverLocation,
     platform,
-    view: viewMode,
+    view: "listings",
     search: searchQuery,
     category: selectedCategory,
     subcategory: selectedSubcategory,
@@ -208,7 +216,6 @@ function Marketplace() {
   }), [
     serverLocation,
     platform,
-    viewMode,
     searchQuery,
     selectedCategory,
     selectedSubcategory,
@@ -272,23 +279,21 @@ function Marketplace() {
       ...(sortOption && { sort: sortOption }),
     };
 
-    if (viewMode === "listings") {
-      if (dealsOnly) params.min_value_index = DEAL_THRESHOLD;
-      fetchMarketListings(params).then((res) => {
+    if (dealsOnly) params.min_value_index = DEAL_THRESHOLD;
+    let isActive = true;
+    fetchMarketListings(params).then((res) => {
+      if (isActive) {
         setItemsData(res.listings || []);
         setTotalItems(res.total || 0);
         setIsLoading(false);
-      });
-    } else {
-      fetchMarketPrices(params).then((res) => {
-        setItemsData(res.items || []);
-        setTotalItems(res.total || 0);
-        setIsLoading(false);
-      });
-    }
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
   }, [
     serverLocation,
-    viewMode,
     selectedCategory,
     selectedSubcategory,
     selectedTrait,
@@ -298,7 +303,8 @@ function Marketplace() {
     searchQuery,
     sortOption,
     dealsOnly,
-    currentPage
+    currentPage,
+    savedSearchRunId,
   ]);
 
   // Derived subcategories list based on selected category
@@ -322,7 +328,7 @@ function Marketplace() {
     setSelectedHubLocation("");
     setSelectedMaxAge("");
     setSearchQuery("");
-    setSortOption(viewMode === "listings" ? "value_index" : "suggested_desc");
+    setSortOption("value_index");
     setDealsOnly(false);
     setCurrentPage(1);
     setSelectedItem(null);
@@ -336,10 +342,37 @@ function Marketplace() {
 
     setSavedSearchesMutating(true);
     setSavedSearchMessage(null);
-    const result = await createSavedSearch(name.trim(), currentSavedSearchFilters);
+    const trimmedName = name.trim();
+    const hasActiveCriteria = Boolean(
+      currentSavedSearchFilters.search ||
+      currentSavedSearchFilters.category ||
+      currentSavedSearchFilters.subcategory ||
+      currentSavedSearchFilters.trait ||
+      currentSavedSearchFilters.rarity ||
+      currentSavedSearchFilters.location ||
+      currentSavedSearchFilters.max_age ||
+      currentSavedSearchFilters.deals_only ||
+      currentSavedSearchFilters.sort !== "value_index"
+    );
+    const filtersToSave = {
+      ...currentSavedSearchFilters,
+      search: hasActiveCriteria ? currentSavedSearchFilters.search : trimmedName,
+    };
+    const result = await createSavedSearch(trimmedName, filtersToSave);
     if (result.success && result.saved_search) {
       setSavedSearches((current) => [result.saved_search, ...current]);
-      setSavedSearchMessage({ type: "success", text: `Saved “${result.saved_search.name}”.` });
+      if (!hasActiveCriteria) {
+        setSearchQuery(trimmedName);
+        setCurrentPage(1);
+        setSelectedItem(null);
+        setSavedSearchRunId((current) => current + 1);
+      }
+      setSavedSearchMessage({
+        type: "success",
+        text: !hasActiveCriteria
+          ? `Saved and searched for “${result.saved_search.name}”.`
+          : `Saved “${result.saved_search.name}”.`,
+      });
       setSavedSearchesMutating(false);
       return true;
     }
@@ -351,21 +384,32 @@ function Marketplace() {
 
   const handleApplySavedSearch = (savedSearch) => {
     const filters = savedSearch.filter_params || {};
-    const nextView = filters.view === "listings" ? "listings" : "prices";
+    const hasStoredCriteria = Boolean(
+      filters.search ||
+      filters.category ||
+      filters.subcategory ||
+      filters.trait ||
+      filters.rarity ||
+      filters.location ||
+      filters.max_age ||
+      filters.deals_only ||
+      (filters.sort && filters.sort !== "value_index" && filters.sort !== "suggested_desc")
+    );
+    const nextSearch = filters.search || (hasStoredCriteria ? "" : savedSearch.name);
     setServerLocation(filters.server === "EU" ? "EU" : "NA");
     setPlatform(["PC", "Xbox", "PlayStation"].includes(filters.platform) ? filters.platform : "PC");
-    setViewMode(nextView);
-    setSearchQuery(filters.search || "");
+    setSearchQuery(nextSearch);
     setSelectedCategory(filters.category || "");
     setSelectedSubcategory(filters.subcategory || "");
     setSelectedTrait(filters.trait || "");
     setSelectedRarity(filters.rarity || "");
     setSelectedHubLocation(filters.location || "");
     setSelectedMaxAge(filters.max_age || "");
-    setSortOption(filters.sort || (nextView === "listings" ? "value_index" : "suggested_desc"));
-    setDealsOnly(nextView === "listings" && filters.deals_only === true);
+    setSortOption(LISTING_SORT_VALUES.has(filters.sort) ? filters.sort : "value_index");
+    setDealsOnly(filters.deals_only === true);
     setCurrentPage(1);
     setSelectedItem(null);
+    setSavedSearchRunId((current) => current + 1);
     setSavedSearchDrawerOpen(false);
     setSavedSearchMessage({ type: "success", text: `Applied “${savedSearch.name}”.` });
   };
@@ -449,7 +493,7 @@ function Marketplace() {
           <div>
             <h1 className="font-cinzel text-2xl md:text-3xl font-extrabold tracking-wide text-[#e0d8c3] flex items-center gap-2 uppercase">
               <Store className="size-7 text-[#c5a059]" />
-              <span>Live Trading House & Price Index</span>
+              <span>Live Guild Trader Listings</span>
             </h1>
             <p className="text-[#a89f91] text-xs md:text-sm mt-1">
               Real-time market analytics, active guild trader listings, and deal intelligence for{" "}
@@ -474,38 +518,9 @@ function Marketplace() {
               </EsoTooltip>
             )}
 
-            {/* View Mode Toggle */}
-            <div className="flex items-center gap-1 bg-[#0a0a0d] p-1 border border-[#2a2c33]">
-              <Button
-                variant={viewMode === "listings" ? "default" : "ghost"}
-                size="sm"
-                onClick={() => {
-                  setViewMode("listings");
-                  setSortOption("value_index");
-                  setCurrentPage(1);
-                }}
-                className={`rounded-none gap-1.5 text-xs font-cinzel font-semibold uppercase cursor-pointer ${
-                  viewMode === "listings" ? "bg-[#c5a059] text-[#0a0a0d] hover:bg-[#d4af37]" : "text-[#a89f91] hover:text-[#e0d8c3]"
-                }`}
-              >
-                <Tag className="size-3.5" />
-                <span>Active Listings {viewMode === "listings" ? `(${totalItems})` : ""}</span>
-              </Button>
-              <Button
-                variant={viewMode === "prices" ? "default" : "ghost"}
-                size="sm"
-                onClick={() => {
-                  setViewMode("prices");
-                  setSortOption("suggested_desc");
-                  setCurrentPage(1);
-                }}
-                className={`rounded-none gap-1.5 text-xs font-cinzel font-semibold uppercase cursor-pointer ${
-                  viewMode === "prices" ? "bg-[#c5a059] text-[#0a0a0d] hover:bg-[#d4af37]" : "text-[#a89f91] hover:text-[#e0d8c3]"
-                }`}
-              >
-                <TrendingUp className="size-3.5" />
-                <span>Catalog Price Index {viewMode === "prices" ? `(${totalItems.toLocaleString()})` : ""}</span>
-              </Button>
+            <div className="flex h-9 items-center gap-2 border border-[#c5a059]/50 bg-[#c5a059]/10 px-4 text-xs font-cinzel font-semibold uppercase tracking-wider text-[#d4af37]">
+              <Tag className="size-3.5" />
+              <span>Active Listings ({totalItems.toLocaleString()})</span>
             </div>
           </div>
         </div>
@@ -526,9 +541,6 @@ function Marketplace() {
                 onChange={(e) => {
                   const loc = e.target.value;
                   setSelectedHubLocation(loc);
-                  if (loc && viewMode !== "listings") {
-                    setViewMode("listings");
-                  }
                   setCurrentPage(1);
                 }}
                 className="w-full bg-[#0a0a0d] border-[#2a2c33] text-[#e0d8c3] text-xs h-9"
@@ -743,25 +755,23 @@ function Marketplace() {
         </NativeSelect>
 
         {/* Time Since Last Seen NativeSelect */}
-        {viewMode === "listings" && (
-          <NativeSelect
-            value={selectedMaxAge}
-            onChange={(e) => {
-              setSelectedMaxAge(e.target.value);
-              setCurrentPage(1);
-            }}
-            className="w-full bg-[#0a0a0d] border-[#2a2c33] text-[#e0d8c3]"
-          >
-            <NativeSelectOption value="">Last Seen: Any Time</NativeSelectOption>
-            <NativeSelectOptGroup label="Scan Recency Scale">
-              <NativeSelectOption value="1">⏱️ Last 24 Hours</NativeSelectOption>
-              <NativeSelectOption value="3">⏱️ Last 3 Days</NativeSelectOption>
-              <NativeSelectOption value="7">⏱️ Last 7 Days</NativeSelectOption>
-              <NativeSelectOption value="14">⏱️ Last 14 Days</NativeSelectOption>
-              <NativeSelectOption value="30">⏱️ Last 30 Days</NativeSelectOption>
-            </NativeSelectOptGroup>
-          </NativeSelect>
-        )}
+        <NativeSelect
+          value={selectedMaxAge}
+          onChange={(e) => {
+            setSelectedMaxAge(e.target.value);
+            setCurrentPage(1);
+          }}
+          className="w-full bg-[#0a0a0d] border-[#2a2c33] text-[#e0d8c3]"
+        >
+          <NativeSelectOption value="">Last Seen: Any Time</NativeSelectOption>
+          <NativeSelectOptGroup label="Scan Recency Scale">
+            <NativeSelectOption value="1">⏱️ Last 24 Hours</NativeSelectOption>
+            <NativeSelectOption value="3">⏱️ Last 3 Days</NativeSelectOption>
+            <NativeSelectOption value="7">⏱️ Last 7 Days</NativeSelectOption>
+            <NativeSelectOption value="14">⏱️ Last 14 Days</NativeSelectOption>
+            <NativeSelectOption value="30">⏱️ Last 30 Days</NativeSelectOption>
+          </NativeSelectOptGroup>
+        </NativeSelect>
 
         {/* Sort Option NativeSelect */}
         <NativeSelect
@@ -773,26 +783,14 @@ function Marketplace() {
           className="w-full bg-[#0a0a0d] border-[#2a2c33] text-[#e0d8c3]"
         >
           <NativeSelectOptGroup label="Sort By">
-            {viewMode === "listings" ? (
-              <>
-                <NativeSelectOption value="value_index">🔥 Best Value Deals</NativeSelectOption>
-                <NativeSelectOption value="trait_asc">Trait: A → Z</NativeSelectOption>
-                <NativeSelectOption value="trait_desc">Trait: Z → A</NativeSelectOption>
-                <NativeSelectOption value="rarity_desc">Rarity: Legendary → Normal</NativeSelectOption>
-                <NativeSelectOption value="rarity_asc">Rarity: Normal → Legendary</NativeSelectOption>
-                <NativeSelectOption value="price_asc">Price: Low to High</NativeSelectOption>
-                <NativeSelectOption value="price_desc">Price: High to Low</NativeSelectOption>
-                <NativeSelectOption value="newest">Recently Discovered</NativeSelectOption>
-              </>
-            ) : (
-              <>
-                <NativeSelectOption value="suggested_desc">Suggested Price: High to Low</NativeSelectOption>
-                <NativeSelectOption value="rarity_desc">Rarity: Legendary → Normal</NativeSelectOption>
-                <NativeSelectOption value="rarity_asc">Rarity: Normal → Legendary</NativeSelectOption>
-                <NativeSelectOption value="price_asc">Suggested Price: Low to High</NativeSelectOption>
-                <NativeSelectOption value="name_asc">Item Name (A-Z)</NativeSelectOption>
-              </>
-            )}
+            <NativeSelectOption value="value_index">🔥 Best Value Deals</NativeSelectOption>
+            <NativeSelectOption value="trait_asc">Trait: A → Z</NativeSelectOption>
+            <NativeSelectOption value="trait_desc">Trait: Z → A</NativeSelectOption>
+            <NativeSelectOption value="rarity_desc">Rarity: Legendary → Normal</NativeSelectOption>
+            <NativeSelectOption value="rarity_asc">Rarity: Normal → Legendary</NativeSelectOption>
+            <NativeSelectOption value="price_asc">Price: Low to High</NativeSelectOption>
+            <NativeSelectOption value="price_desc">Price: High to Low</NativeSelectOption>
+            <NativeSelectOption value="newest">Recently Discovered</NativeSelectOption>
           </NativeSelectOptGroup>
         </NativeSelect>
       </div>
@@ -815,22 +813,20 @@ function Marketplace() {
             Saved Searches{savedSearches.length ? ` (${savedSearches.length})` : ""}
           </Button>
 
-          {viewMode === "listings" && (
-            <Button
-              variant={dealsOnly ? "default" : "outline"}
-              size="sm"
-              onClick={() => {
-                setDealsOnly(!dealsOnly);
-                setCurrentPage(1);
-              }}
-              className={`rounded-none gap-1.5 font-semibold text-xs border ${
-                dealsOnly ? "bg-[#c5a059] text-[#0a0a0d] border-[#c5a059]" : "border-[#c5a059]/40 text-[#d4af37] bg-[#161620]"
-              }`}
-            >
-              <Sparkles className="size-3.5 text-[#c5a059]" />
-              <span>Only Bargain Deals (1.2x+ Value)</span>
-            </Button>
-          )}
+          <Button
+            variant={dealsOnly ? "default" : "outline"}
+            size="sm"
+            onClick={() => {
+              setDealsOnly(!dealsOnly);
+              setCurrentPage(1);
+            }}
+            className={`rounded-none gap-1.5 font-semibold text-xs border ${
+              dealsOnly ? "bg-[#c5a059] text-[#0a0a0d] border-[#c5a059]" : "border-[#c5a059]/40 text-[#d4af37] bg-[#161620]"
+            }`}
+          >
+            <Sparkles className="size-3.5 text-[#c5a059]" />
+            <span>Only Bargain Deals (1.2x+ Value)</span>
+          </Button>
 
           {(selectedCategory || selectedSubcategory || selectedTrait || selectedRarity || selectedHubLocation || selectedMaxAge || searchQuery || dealsOnly) && (
             <Button
@@ -874,7 +870,7 @@ function Marketplace() {
           <SavedSearchesCard {...savedSearchesCardProps} />
         </aside>
 
-        {/* Listings / Prices Grid */}
+        {/* Active Listings Grid */}
         <div className={selectedItem ? "lg:col-span-2 space-y-4" : "lg:col-span-3 space-y-4"}>
           {isLoading ? (
             <div className="eso-card flex flex-col items-center justify-center p-12 text-center">
@@ -883,67 +879,40 @@ function Marketplace() {
             </div>
           ) : itemsData.length === 0 ? (
             <div className="eso-card flex flex-col items-center justify-center p-12 text-center">
-              {viewMode === "listings" ? (
-                <>
-                  <Store className="size-12 text-[#c5a059]/60 mb-3" />
-                  <h3 className="font-cinzel text-xl font-bold text-[#e0d8c3] mb-1">
-                    {searchQuery ? `No Active Listings Found for "${searchQuery}"` : "No Guild Trader Scans Logged"}
-                  </h3>
-                  <p className="text-xs text-[#a89f91] max-w-lg mb-4 leading-relaxed">
-                    {searchQuery
-                      ? `Click below to trigger a live search scan across ESO guild traders for "${searchQuery}".`
-                      : "Synthetic listings have been purged. You can view all 155,476 authentic market price statistics in the Catalog Price Index, or run python data-pipeline/parse_saved_variables.py to load your in-game TTC addon scans."}
-                  </p>
-                  <div className="flex flex-wrap items-center justify-center gap-3">
-                    {searchQuery && (
-                      <Button
-                        variant="default"
-                        onClick={async () => {
-                          setIsLoading(true);
-                          const res = await extractLiveListings(searchQuery, serverLocation);
-                          if (res.listings) {
-                            setItemsData(res.listings);
-                            setTotalItems(res.count || res.listings.length);
-                          }
-                          setIsLoading(false);
-                        }}
-                        className="rounded-none gap-2 font-cinzel font-bold bg-[#c5a059] text-[#0a0a0d] hover:bg-[#d4af37]"
-                      >
-                        <Zap className="size-4" />
-                        <span>Fetch Live Market Scans for "{searchQuery}"</span>
-                      </Button>
-                    )}
-                    <Button
-                      variant={searchQuery ? "outline" : "default"}
-                      onClick={() => {
-                        setViewMode("prices");
-                        setSortOption("suggested_desc");
-                        setCurrentPage(1);
-                      }}
-                      className="rounded-none gap-2 font-cinzel font-bold border-[#c5a059]/40 bg-[#161620] text-[#e0d8c3] hover:border-[#c5a059]"
-                    >
-                      <TrendingUp className="size-4 text-[#c5a059]" />
-                      <span>Switch to Catalog Price Index (155,476 Items)</span>
-                    </Button>
-                    {(selectedCategory || selectedSubcategory || selectedTrait || selectedRarity || selectedHubLocation || searchQuery) && (
-                      <Button variant="outline" size="sm" onClick={handleResetFilters} className="rounded-none">
-                        Clear Filters
-                      </Button>
-                    )}
-                  </div>
-                </>
-              ) : (
-                <>
-                  <Info className="size-10 text-[#8a8275] mb-2" />
-                  <h3 className="font-cinzel text-lg font-bold text-[#e0d8c3] mb-1">No catalog entries found</h3>
-                  <p className="text-xs text-[#a89f91] max-w-md mb-4">
-                    Try adjusting your search keywords, category filters, or switching servers in the top navbar.
-                  </p>
-                  <Button variant="outline" size="sm" onClick={handleResetFilters} className="rounded-none">
-                    Clear All Filters
+              <Store className="size-12 text-[#c5a059]/60 mb-3" />
+              <h3 className="font-cinzel text-xl font-bold text-[#e0d8c3] mb-1">
+                {searchQuery ? `No Active Listings Found for "${searchQuery}"` : "No Guild Trader Scans Logged"}
+              </h3>
+              <p className="text-xs text-[#a89f91] max-w-lg mb-4 leading-relaxed">
+                {searchQuery
+                  ? `Click below to trigger a live search scan across ESO guild traders for "${searchQuery}".`
+                  : "No authentic guild trader listings match these filters yet. Load in-game ESOTrade scans or adjust the filters to search the active listing feed."}
+              </p>
+              <div className="flex flex-wrap items-center justify-center gap-3">
+                {searchQuery && (
+                  <Button
+                    variant="default"
+                    onClick={async () => {
+                      setIsLoading(true);
+                      const res = await extractLiveListings(searchQuery, serverLocation);
+                      if (res.listings) {
+                        setItemsData(res.listings);
+                        setTotalItems(res.count || res.listings.length);
+                      }
+                      setIsLoading(false);
+                    }}
+                    className="rounded-none gap-2 font-cinzel font-bold bg-[#c5a059] text-[#0a0a0d] hover:bg-[#d4af37]"
+                  >
+                    <Zap className="size-4" />
+                    <span>Fetch Live Market Scans for "{searchQuery}"</span>
                   </Button>
-                </>
-              )}
+                )}
+                {(selectedCategory || selectedSubcategory || selectedTrait || selectedRarity || selectedHubLocation || searchQuery) && (
+                  <Button variant="outline" size="sm" onClick={handleResetFilters} className="rounded-none">
+                    Clear Filters
+                  </Button>
+                )}
+              </div>
             </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 gap-4">
@@ -1011,66 +980,49 @@ function Marketplace() {
                     </CardHeader>
 
                     <CardContent className="p-4 pt-2">
-                      {viewMode === "listings" ? (
-                        <div className="space-y-2 text-xs">
-                          <div className="flex items-center justify-between border-t border-[#2a2c33]/40 pt-2">
-                            <div className="flex items-center gap-1.5">
-                              <span className="text-[#a89f91]">Unit Price:</span>
-                              <span className="bg-[#161620] text-[#d4af37] font-mono font-bold px-1.5 py-0.5 text-[10px] border border-[#2a2c33]">
-                                x{item.quantity || 1}/stack
-                              </span>
-                            </div>
-                            <div className="text-right">
-                              <span className="font-bold text-base text-[#c5a059] block font-mono">
-                                {formatGold(item.price)}
-                                <span className="text-[10px] text-[#8a8275] font-normal ml-0.5">/ea</span>
-                              </span>
-                              <span className="text-[10px] text-[#8a8275] block font-mono">
-                                Total/stack: {formatGold((item.price || 0) * (item.quantity || 1))}
-                              </span>
-                            </div>
+                      <div className="space-y-2 text-xs">
+                        <div className="flex items-center justify-between border-t border-[#2a2c33]/40 pt-2">
+                          <div className="flex items-center gap-1.5">
+                            <span className="text-[#a89f91]">Unit Price:</span>
+                            <span className="bg-[#161620] text-[#d4af37] font-mono font-bold px-1.5 py-0.5 text-[10px] border border-[#2a2c33]">
+                              x{item.quantity || 1}/stack
+                            </span>
                           </div>
-
-                          {/* Smart Seller Inventory & Stacks Badge */}
-                          <div className="flex items-center justify-between text-xs bg-[#0a0a0d] border border-[#2a2c33] px-2.5 py-1.5 mt-2">
-                            <div className="flex items-center gap-1.5 font-semibold text-[#d4af37]">
-                              <Layers className="size-3.5 text-[#c5a059] shrink-0" />
-                              <span>
-                                {(item.active_stacks || 1) > 1
-                                  ? `📦 ${item.active_stacks} Stacks Available (${((item.quantity || 1) * item.active_stacks).toLocaleString()} total)`
-                                  : `1 Stack Available (${item.quantity || 1} total)`}
-                              </span>
-                            </div>
-                            <EsoTooltip content={`Seller Account: ${item.seller_name || "@Unknown"}`} side="top">
-                              <span className="font-mono text-[#a89f91] text-[11px] truncate max-w-[110px] cursor-default">
-                                {item.seller_name || "@Unknown"}
-                              </span>
-                            </EsoTooltip>
-                          </div>
-
-                          <div className="flex items-center justify-between">
-                            <span className="text-[#a89f91]">Suggested Value:</span>
-                            <span className="font-medium text-[#d4af37] font-mono">
-                              {formatGold(item.suggested_price)}
+                          <div className="text-right">
+                            <span className="font-bold text-base text-[#c5a059] block font-mono">
+                              {formatGold(item.price)}
+                              <span className="text-[10px] text-[#8a8275] font-normal ml-0.5">/ea</span>
+                            </span>
+                            <span className="text-[10px] text-[#8a8275] block font-mono">
+                              Total/stack: {formatGold((item.price || 0) * (item.quantity || 1))}
                             </span>
                           </div>
                         </div>
-                      ) : (
-                        <div className="space-y-1.5 text-xs border-t border-[#2a2c33]/40 pt-2 font-mono">
-                          <div className="flex items-center justify-between">
-                            <span className="text-[#a89f91] font-sans">Suggested Price:</span>
-                            <span className="font-bold text-[#c5a059]">{formatGold(item.suggested_price)}</span>
+
+                        {/* Smart Seller Inventory & Stacks Badge */}
+                        <div className="flex items-center justify-between text-xs bg-[#0a0a0d] border border-[#2a2c33] px-2.5 py-1.5 mt-2">
+                          <div className="flex items-center gap-1.5 font-semibold text-[#d4af37]">
+                            <Layers className="size-3.5 text-[#c5a059] shrink-0" />
+                            <span>
+                              {(item.active_stacks || 1) > 1
+                                ? `📦 ${item.active_stacks} Stacks Available (${((item.quantity || 1) * item.active_stacks).toLocaleString()} total)`
+                                : `1 Stack Available (${item.quantity || 1} total)`}
+                            </span>
                           </div>
-                          <div className="flex items-center justify-between text-[#8a8275]">
-                            <span className="font-sans">Avg Market Price:</span>
-                            <span>{formatGold(item.avg_price)}</span>
-                          </div>
-                          <div className="flex items-center justify-between text-[11px] text-[#8a8275]">
-                            <span className="font-sans">Price Range:</span>
-                            <span>{formatGold(item.min_price)} - {formatGold(item.max_price)}</span>
-                          </div>
+                          <EsoTooltip content={`Seller Account: ${item.seller_name || "@Unknown"}`} side="top">
+                            <span className="font-mono text-[#a89f91] text-[11px] truncate max-w-[110px] cursor-default">
+                              {item.seller_name || "@Unknown"}
+                            </span>
+                          </EsoTooltip>
                         </div>
-                      )}
+
+                        <div className="flex items-center justify-between">
+                          <span className="text-[#a89f91]">Suggested Value:</span>
+                          <span className="font-medium text-[#d4af37] font-mono">
+                            {formatGold(item.suggested_price)}
+                          </span>
+                        </div>
+                      </div>
 
                       {/* Prominent Guild Trader Name, Location, & Last Seen Marker */}
                       <div className="flex items-center justify-between text-[11px] text-[#8a8275] pt-2 mt-2 border-t border-[#2a2c33]/40 gap-1">


### PR DESCRIPTION
## Summary

- add private SQLite-backed saved Marketplace searches for authenticated users
- add account-scoped create/list/pin/delete APIs with validation and ownership guards
- make Marketplace a live-guild-listings-only experience and remove the Catalog Price Index mode
- add a persistent desktop sidebar, pinned quick filters, and a mobile saved-search drawer
- ensure saved rows and pinned chips populate the main query and force a fresh listings request
- document the schema and cover the complete API lifecycle in integration tests

## Verification

- `npm test` (backend): all 55 API endpoint suites passed
- `npm run build` (frontend): passed
- `npx oxlint src/pages/Marketplace.jsx src/components/SavedSearchesCard.jsx`: passed
- `node --check backend/server.js`: passed
- rendered desktop and 390px mobile flows: signed-out prompt, save, pin, reset/apply from row and chip, live-only header, and zero console errors
- reproduced the review case with a filterless `lockpick` preset: the main search populated and the live result request changed the feed from 2 results to 0

## Known repository baseline

- The repository-wide frontend lint command still reports the pre-existing conditional Hook error in `src/components/dev/DevAccountModal.jsx`; the Marketplace files changed here pass focused lint.

Closes #82