### PR TITLE
fix(#78): enforce bcrypt-only authentication

### DIFF
--- a/backend/data-pipeline/test_api_endpoints.js
+++ b/backend/data-pipeline/test_api_endpoints.js
@@ -175,6 +175,7 @@ function testDbRun(sql, params = []) {
     return new Promise((resolve, reject) => {
         const testDb = new sqlite3.Database(EPHEMERAL_DB, (openErr) => {
             if (openErr) return reject(openErr);
+            testDb.configure('busyTimeout', 5000);
             testDb.run(sql, params, function(runErr) {
                 const result = { lastID: this.lastID, changes: this.changes };
                 testDb.close((closeErr) => {
@@ -191,6 +192,7 @@ function testDbAll(sql, params = []) {
     return new Promise((resolve, reject) => {
         const testDb = new sqlite3.Database(EPHEMERAL_DB, (openErr) => {
             if (openErr) return reject(openErr);
+            testDb.configure('busyTimeout', 5000);
             testDb.all(sql, params, (queryErr, rows) => {
                 testDb.close((closeErr) => {
                     if (queryErr) reject(queryErr);

--- a/backend/data-pipeline/test_api_endpoints.js
+++ b/backend/data-pipeline/test_api_endpoints.js
@@ -1,26 +1,84 @@
 const fs = require('fs');
 const http = require('http');
+const crypto = require('crypto');
 const { spawn } = require('child_process');
 const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
 
 const PORT = 5002;
 const SERVER_PATH = path.join(__dirname, '..', 'server.js');
 const EPHEMERAL_DB = process.env.DB_PATH || path.join(__dirname, `scratch_test_${Date.now()}.db`);
+const PREMIGRATION_LEGACY_USER_ID = 90;
+const PREMIGRATION_LEGACY_PASSWORD = 'PreMigrationLegacy123!';
 
 console.log("Starting temporary test server on port " + PORT + " with sandbox DB: " + path.basename(EPHEMERAL_DB) + "...");
 
-const serverProcess = spawn('node', [SERVER_PATH], {
-    env: { ...process.env, PORT: PORT, DB_PATH: EPHEMERAL_DB, NODE_ENV: process.env.NODE_ENV || 'test', ENABLE_DEV_ENDPOINTS: 'true' },
-    stdio: 'pipe'
-});
+let serverProcess = null;
 
-serverProcess.stdout.on('data', (data) => {
-    // console.log(`[Server]: ${data}`);
-});
+function startTestServer() {
+    const child = spawn('node', [SERVER_PATH], {
+        env: { ...process.env, PORT: PORT, DB_PATH: EPHEMERAL_DB, NODE_ENV: process.env.NODE_ENV || 'test', ENABLE_DEV_ENDPOINTS: 'true' },
+        stdio: 'pipe'
+    });
 
-serverProcess.stderr.on('data', (data) => {
-    console.error(`[Server Error]: ${data}`);
-});
+    child.stdout.on('data', (data) => {
+        // console.log(`[Server]: ${data}`);
+    });
+
+    child.stderr.on('data', (data) => {
+        console.error(`[Server Error]: ${data}`);
+    });
+
+    return child;
+}
+
+function seedPreMigrationLegacyAccount() {
+    if (process.env.DB_PATH) return Promise.resolve();
+
+    return new Promise((resolve, reject) => {
+        const seedDb = new sqlite3.Database(EPHEMERAL_DB, (openErr) => {
+            if (openErr) return reject(openErr);
+
+            const legacyHash = crypto.createHash('sha256').update(PREMIGRATION_LEGACY_PASSWORD).digest('hex');
+            seedDb.serialize(() => {
+                seedDb.run(`
+                    CREATE TABLE users (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        username TEXT UNIQUE NOT NULL,
+                        email TEXT UNIQUE NOT NULL,
+                        password_hash TEXT NOT NULL,
+                        eso_handle TEXT,
+                        api_token TEXT UNIQUE,
+                        role TEXT DEFAULT 'user',
+                        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                    );
+                `);
+                seedDb.run(`
+                    CREATE TABLE sessions (
+                        token TEXT PRIMARY KEY,
+                        user_id INTEGER NOT NULL,
+                        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                        expires_at TEXT NOT NULL,
+                        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                    );
+                `);
+                seedDb.run(`
+                    INSERT INTO users (id, username, email, password_hash, eso_handle, api_token, role)
+                    VALUES (?, 'PreMigrationLegacy', 'premigration@example.test', ?, '@PreMigrationLegacy', 'premigration_api_token', 'user');
+                `, [PREMIGRATION_LEGACY_USER_ID, legacyHash]);
+                seedDb.run(`
+                    INSERT INTO sessions (token, user_id, expires_at)
+                    VALUES ('premigration_session_token', ?, ?);
+                `, [PREMIGRATION_LEGACY_USER_ID, new Date(Date.now() + 60 * 60 * 1000).toISOString()]);
+            });
+
+            seedDb.close((closeErr) => {
+                if (closeErr) reject(closeErr);
+                else resolve();
+            });
+        });
+    });
+}
 
 function httpGet(path, headers = {}) {
     return new Promise((resolve, reject) => {
@@ -113,7 +171,41 @@ function httpPatch(path, body = {}, headers = {}) {
     });
 }
 
+function testDbRun(sql, params = []) {
+    return new Promise((resolve, reject) => {
+        const testDb = new sqlite3.Database(EPHEMERAL_DB, (openErr) => {
+            if (openErr) return reject(openErr);
+            testDb.run(sql, params, function(runErr) {
+                const result = { lastID: this.lastID, changes: this.changes };
+                testDb.close((closeErr) => {
+                    if (runErr) reject(runErr);
+                    else if (closeErr) reject(closeErr);
+                    else resolve(result);
+                });
+            });
+        });
+    });
+}
+
+function testDbAll(sql, params = []) {
+    return new Promise((resolve, reject) => {
+        const testDb = new sqlite3.Database(EPHEMERAL_DB, (openErr) => {
+            if (openErr) return reject(openErr);
+            testDb.all(sql, params, (queryErr, rows) => {
+                testDb.close((closeErr) => {
+                    if (queryErr) reject(queryErr);
+                    else if (closeErr) reject(closeErr);
+                    else resolve(rows);
+                });
+            });
+        });
+    });
+}
+
 async function runTests() {
+    await seedPreMigrationLegacyAccount();
+    serverProcess = startTestServer();
+
     // Poll server health up to 10 seconds for robust startup across all runner environments
     let serverReady = false;
     for (let attempt = 0; attempt < 20; attempt++) {
@@ -134,6 +226,38 @@ async function runTests() {
     let createdUserId = null;
 
     try {
+        if (!process.env.DB_PATH) {
+            console.log("\n0. Testing pre-migration legacy-account audit and disablement...");
+            let migratedLegacyRows = [];
+            for (let attempt = 0; attempt < 20; attempt++) {
+                migratedLegacyRows = await testDbAll(
+                    "SELECT id, password_hash, api_token FROM users WHERE id = ?;",
+                    [PREMIGRATION_LEGACY_USER_ID]
+                );
+                if (migratedLegacyRows[0] && /^\$2[aby]\$/.test(migratedLegacyRows[0].password_hash)) break;
+                await new Promise(r => setTimeout(r, 100));
+            }
+            const migratedLegacy = migratedLegacyRows[0];
+            if (!migratedLegacy || !/^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/.test(migratedLegacy.password_hash)) {
+                throw new Error("Pre-existing legacy account was not replaced with a disabled bcrypt credential.");
+            }
+            if (migratedLegacy.api_token !== null) {
+                throw new Error("Pre-existing legacy account API token was not revoked.");
+            }
+            const migratedSessions = await testDbAll("SELECT token FROM sessions WHERE user_id = ?;", [PREMIGRATION_LEGACY_USER_ID]);
+            if (migratedSessions.length !== 0) {
+                throw new Error("Pre-existing legacy account sessions were not revoked.");
+            }
+            const migratedLegacyLogin = await httpPost('/api/auth/login', {
+                usernameOrEmail: 'PreMigrationLegacy',
+                password: PREMIGRATION_LEGACY_PASSWORD
+            });
+            if (migratedLegacyLogin.status !== 401) {
+                throw new Error(`Pre-migration legacy password returned status ${migratedLegacyLogin.status}, expected 401`);
+            }
+            console.log("   Legacy account credential, sessions, and API token were invalidated without rehashing unknown plaintext.");
+        }
+
         console.log("\n1. Testing GET /api/taxonomy...");
         const taxRes = await httpGet('/api/taxonomy');
         console.log(`   Status: ${taxRes.status}, Categories found: ${Object.keys(taxRes.data).length}`);
@@ -226,15 +350,47 @@ async function runTests() {
             throw new Error(`Auth /me failed with status ${meRes.status}`);
         }
 
-        console.log("\n10. Testing Legacy SHA-256 account login & automatic bcrypt migration...");
-        const legacyLoginRes = await httpPost('/api/auth/login', {
-            usernameOrEmail: "Blake",
-            password: "password123"
-        });
-        console.log(`   Status: ${legacyLoginRes.status}, User: @${legacyLoginRes.data.user?.username}`);
-        if (legacyLoginRes.status !== 200 || !legacyLoginRes.data.token) {
-            throw new Error(`Legacy user login failed with status ${legacyLoginRes.status}`);
+        console.log("\n9b. Testing development fixtures use bcrypt-only credentials...");
+        const fixtureHashes = await testDbAll("SELECT id, password_hash FROM users WHERE id IN (1, 2) ORDER BY id;");
+        const bcryptHashPattern = /^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/;
+        if (fixtureHashes.length !== 2 || fixtureHashes.some((row) => !bcryptHashPattern.test(row.password_hash))) {
+            throw new Error("Development fixtures were not created or reset with valid bcrypt hashes.");
         }
+        console.log("   Blake and Demo fixtures both use valid bcrypt hashes.");
+
+        console.log("\n10. Testing rejection of a legacy SHA-256 credential and its existing tokens...");
+        const legacyPassword = "LegacyPassword123!";
+        const legacyHash = crypto.createHash("sha256").update(legacyPassword).digest("hex");
+        const legacyApiToken = `legacy_api_${crypto.randomBytes(12).toString("hex")}`;
+        const legacyUsername = `LegacyTester_${Date.now()}`;
+        const legacyUser = await testDbRun(`
+            INSERT INTO users (username, email, password_hash, eso_handle, api_token, role)
+            VALUES (?, ?, ?, ?, ?, 'user');
+        `, [legacyUsername, `legacy_${Date.now()}@example.test`, legacyHash, '@LegacyTester', legacyApiToken]);
+        const legacySessionToken = `legacy_session_${crypto.randomBytes(12).toString("hex")}`;
+        await testDbRun(
+            "INSERT INTO sessions (token, user_id, expires_at) VALUES (?, ?, ?);",
+            [legacySessionToken, legacyUser.lastID, new Date(Date.now() + 60 * 60 * 1000).toISOString()]
+        );
+
+        const legacyLoginRes = await httpPost('/api/auth/login', {
+            usernameOrEmail: legacyUsername,
+            password: legacyPassword
+        });
+        if (legacyLoginRes.status !== 401) {
+            throw new Error(`Legacy SHA-256 credential returned status ${legacyLoginRes.status}, expected 401`);
+        }
+
+        const legacySessionRes = await httpGet('/api/auth/me', { 'Authorization': `Bearer ${legacySessionToken}` });
+        if (legacySessionRes.status !== 401) {
+            throw new Error(`Legacy account session returned status ${legacySessionRes.status}, expected 401`);
+        }
+
+        const legacyApiTokenRes = await httpGet('/api/auth/me', { 'Authorization': `Bearer ${legacyApiToken}` });
+        if (legacyApiTokenRes.status !== 401) {
+            throw new Error(`Legacy account API token returned status ${legacyApiTokenRes.status}, expected 401`);
+        }
+        console.log("   Legacy password, session, and API token authentication were all rejected.");
 
         console.log("\n11. Testing GET /api/auth/me with invalid/unauthorized token (expect 401)...");
         const badTokenRes = await httpGet('/api/auth/me', { 'Authorization': 'Bearer bogus-random-token-xyz' });
@@ -1023,12 +1179,12 @@ async function runTests() {
         }
         console.log("   Saved-search create/list/pin/delete behavior and cross-account isolation verified!");
 
-        console.log("\nAll 55 API endpoint test suites passed successfully!");
+        console.log("\nAll 55 API endpoint suites plus bcrypt migration regressions passed successfully!");
     } catch (err) {
         console.error("API test failed:", err);
         process.exitCode = 1;
     } finally {
-        serverProcess.kill();
+        if (serverProcess) serverProcess.kill();
         // Give server process a brief moment to release file lock before unlinking test DB
         setTimeout(() => {
             try {

--- a/backend/server.js
+++ b/backend/server.js
@@ -27,6 +27,26 @@ const { seedCuratedMetaBuilds } = require("./curated_builds");
 const app = express();
 const PORT = process.env.PORT || 5001;
 
+const BCRYPT_SALT_ROUNDS = 12;
+const BCRYPT_HASH_PATTERN = /^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/;
+
+function hashPassword(password) {
+    return bcrypt.hashSync(password || "", BCRYPT_SALT_ROUNDS);
+}
+
+function isBcryptHash(storedHash) {
+    return typeof storedHash === "string" && BCRYPT_HASH_PATTERN.test(storedHash);
+}
+
+function verifyPassword(password, storedHash) {
+    if (!password || !isBcryptHash(storedHash)) return false;
+    try {
+        return bcrypt.compareSync(password, storedHash);
+    } catch {
+        return false;
+    }
+}
+
 // Developer & Testing Environment Flag (defaults to 'development' if NODE_ENV is unset)
 const nodeEnv = process.env.NODE_ENV || "development";
 const isDevMode = (nodeEnv === "development" || nodeEnv === "test" || process.env.ENABLE_DEV_ENDPOINTS === "true") && process.env.NODE_ENV !== "production";
@@ -185,6 +205,81 @@ const db = new sqlite3.Database(dbPath, (err) => {
 });
 
 /**
+ * Reports and disables accounts whose stored credential is not bcrypt.
+ * The report intentionally excludes password hashes, API tokens, and email addresses.
+ */
+function scheduleLegacyPasswordRemediation() {
+    db.all(`
+        SELECT id, username, role, created_at, password_hash
+        FROM users
+        ORDER BY id ASC;
+    `, [], (auditErr, rows) => {
+        if (auditErr) {
+            console.error("[AUTH MIGRATION] Failed to inventory non-bcrypt accounts:", auditErr.message);
+            return;
+        }
+
+        const legacyAccounts = rows.filter((row) => !isBcryptHash(row.password_hash));
+        const safeReport = legacyAccounts.map(({ id, username, role, created_at }) => ({
+            id,
+            username,
+            role,
+            created_at
+        }));
+        console.log(`[AUTH MIGRATION] Pre-migration report: ${safeReport.length} non-bcrypt account(s).`, safeReport);
+
+        if (legacyAccounts.length === 0) return;
+
+        // The two built-in development fixtures are reset to bcrypt by the next
+        // queued schema step. Every other legacy account is explicitly disabled.
+        const accountsToDisable = isDevMode
+            ? legacyAccounts.filter((account) => ![1, 2].includes(account.id))
+            : legacyAccounts;
+        if (accountsToDisable.length === 0) return;
+
+        const accountIds = accountsToDisable.map((account) => account.id);
+        const placeholders = accountIds.map(() => "?").join(", ");
+        const disabledPasswordHash = hashPassword(crypto.randomBytes(32).toString("hex"));
+
+        const rollback = (migrationErr) => {
+            db.run("ROLLBACK;", (rollbackErr) => {
+                if (rollbackErr) {
+                    console.error("[AUTH MIGRATION] Rollback failed:", rollbackErr.message);
+                }
+                console.error("[AUTH MIGRATION] Failed to disable non-bcrypt accounts:", migrationErr.message);
+            });
+        };
+
+        db.run("BEGIN IMMEDIATE TRANSACTION;", (beginErr) => {
+            if (beginErr) {
+                console.error("[AUTH MIGRATION] Failed to start legacy-account remediation:", beginErr.message);
+                return;
+            }
+
+            db.run(`DELETE FROM sessions WHERE user_id IN (${placeholders});`, accountIds, (sessionErr) => {
+                if (sessionErr) return rollback(sessionErr);
+
+                db.run(`
+                    UPDATE users
+                    SET password_hash = ?, api_token = NULL
+                    WHERE id IN (${placeholders});
+                `, [disabledPasswordHash, ...accountIds], function(updateErr) {
+                    if (updateErr) return rollback(updateErr);
+
+                    const disabledCount = this.changes;
+                    db.run("COMMIT;", (commitErr) => {
+                        if (commitErr) return rollback(commitErr);
+                        console.warn(
+                            `[AUTH MIGRATION] Disabled ${disabledCount} non-bcrypt account(s), revoked their sessions and API tokens, and invalidated their credentials pending a controlled password reset.`
+                        );
+                    });
+                });
+            });
+        });
+    });
+}
+
+/**
  * Initialize characters and knowledge tables if they do not exist
  */
 function initializeDatabaseSchema() {
@@ -281,17 +376,22 @@ function initializeDatabaseSchema() {
         });
         db.run("CREATE INDEX IF NOT EXISTS idx_saved_searches_user ON saved_searches(user_id, is_pinned);");
 
+        scheduleLegacyPasswordRemediation();
+
         if (isDevMode) {
             const seedBlakeToken = process.env.BLAKE_API_TOKEN || crypto.randomBytes(16).toString("hex");
             const seedDemoToken = process.env.DEMO_API_TOKEN || crypto.randomBytes(16).toString("hex");
+            const seedBlakePasswordHash = hashPassword(crypto.randomBytes(32).toString("hex"));
+            const seedDemoPasswordHash = hashPassword(crypto.randomBytes(32).toString("hex"));
             db.run(`
                 INSERT INTO users (id, username, email, password_hash, eso_handle, api_token, role)
                 VALUES 
-                    (1, 'Blake', 'blake@esotrade.local', 'ef92b778bafe771e89245b89ecbc08a44a4e166c06659911881f383d4473e94f', '@Blake', ?, 'admin'),
-                    (2, 'Demo', 'demo@esotrade.local', 'ef92b778bafe771e89245b89ecbc08a44a4e166c06659911881f383d4473e94f', '@Demo', ?, 'user')
+                    (1, 'Blake', 'blake@esotrade.local', ?, '@Blake', ?, 'admin'),
+                    (2, 'Demo', 'demo@esotrade.local', ?, '@Demo', ?, 'user')
                 ON CONFLICT(id) DO UPDATE SET
-                    username = excluded.username;
-            `, [seedBlakeToken, seedDemoToken]);
+                    username = excluded.username,
+                    password_hash = excluded.password_hash;
+            `, [seedBlakePasswordHash, seedBlakeToken, seedDemoPasswordHash, seedDemoToken]);
         }
 
 
@@ -2092,27 +2192,6 @@ if (isDevMode) {
 // ============================================================================
 // AUTHENTICATION & DEVELOPER BYPASS ENDPOINTS
 // ============================================================================
-const BCRYPT_SALT_ROUNDS = 12;
-
-function hashPassword(password) {
-    return bcrypt.hashSync(password || "", BCRYPT_SALT_ROUNDS);
-}
-
-function verifyPassword(password, storedHash) {
-    if (!password || !storedHash) return false;
-    // Check if the stored hash is a bcrypt hash
-    if (storedHash.startsWith("$2a$") || storedHash.startsWith("$2b$") || storedHash.startsWith("$2y$")) {
-        try {
-            return bcrypt.compareSync(password, storedHash);
-        } catch {
-            return false;
-        }
-    }
-    // Legacy fallback: unsalted SHA-256 hash comparison
-    const legacyHash = crypto.createHash("sha256").update(password).digest("hex");
-    return storedHash === legacyHash;
-}
-
 const SESSION_TTL_HOURS = parseInt(process.env.SESSION_TTL_HOURS, 10) || (24 * 7); // Default: 7 days
 
 async function createSession(userId, ttlHours = SESSION_TTL_HOURS) {
@@ -2168,16 +2247,19 @@ async function getAuthUserId(req) {
 
     try {
         const session = await dbGet(
-            `SELECT user_id, expires_at FROM sessions WHERE token = ? AND datetime(expires_at) > datetime('now');`,
+            `SELECT s.user_id, s.expires_at, u.password_hash
+             FROM sessions s
+             JOIN users u ON u.id = s.user_id
+             WHERE s.token = ? AND datetime(s.expires_at) > datetime('now');`,
             [token]
         );
-        if (session) {
+        if (session && isBcryptHash(session.password_hash)) {
             return session.user_id;
         }
 
         // Support direct api_token lookup (for background sync / addon / scripts)
-        const apiKeyUser = await dbGet(`SELECT id FROM users WHERE api_token = ?;`, [token]);
-        if (apiKeyUser) {
+        const apiKeyUser = await dbGet(`SELECT id, password_hash FROM users WHERE api_token = ?;`, [token]);
+        if (apiKeyUser && isBcryptHash(apiKeyUser.password_hash)) {
             return apiKeyUser.id;
         }
 
@@ -2278,13 +2360,6 @@ app.post("/api/auth/login", async (req, res) => {
         const isMatch = verifyPassword(password, user.password_hash);
         if (!isMatch) {
             return res.status(401).json({ error: "Invalid username/email or password." });
-        }
-
-        // If user was stored with legacy SHA-256 hash, transparently migrate to bcrypt
-        if (!user.password_hash.startsWith("$2a$") && !user.password_hash.startsWith("$2b$") && !user.password_hash.startsWith("$2y$")) {
-            const upgradedHash = hashPassword(password);
-            await dbRun(`UPDATE users SET password_hash = ? WHERE id = ?;`, [upgradedHash, user.id]);
-            console.log(`[AUTH] Seamlessly upgraded password hash to bcrypt for user @${user.username} (ID: ${user.id})`);
         }
 
         const userPayload = {


### PR DESCRIPTION
## Summary
- remove the SHA-256 password verification fallback and accept only structurally valid bcrypt credentials
- audit non-bcrypt accounts at startup, log a secret-free migration report, and disable remaining legacy accounts by revoking sessions/API tokens and replacing their credential with an unknown bcrypt value
- reset the built-in development fixtures through the normal bcrypt hashing path
- reject session and API-token authentication for accounts without valid bcrypt credentials
- add regressions for bcrypt success, invalid-password rejection, startup remediation, and post-startup legacy password/session/token rejection

## Verification
- `cd backend && node --check server.js`
- `cd backend && node --check data-pipeline/test_api_endpoints.js`
- `cd backend && npm test` (55 endpoint suites plus bcrypt migration regressions)
- `cd frontend && npm run build`

Closes #78