### PR TITLE
[Draft] Fix #113: Prevent ESOTrade watcher self-trigger loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
         run: |
           python test_db_queries.py
 
+      - name: Run Watcher Feedback Loop Regression Tests
+        working-directory: backend/data-pipeline
+        run: |
+          python test_watcher.py
+
   frontend-build:
     name: Frontend Production Build
     runs-on: ubuntu-latest

--- a/backend/data-pipeline/README.md
+++ b/backend/data-pipeline/README.md
@@ -29,4 +29,10 @@ Or continuously watch the standard ESO SavedVariables locations:
 python3 data-pipeline/watcher.py
 ```
 
+Set `ESOTRADE_AUTH_TOKEN` to the current API token before starting the watcher
+when remote API synchronization is required. Without it, native data is still
+written to the local SQLite database, but authenticated API pushes are skipped.
+The watcher records the parser's post-import auto-clear write and waits for the
+next genuine ESO SavedVariables update instead of processing its own write.
+
 Only `ESOTrade.lua` is accepted for live listing observations. Aggregates such as observed minimum, maximum, average, and count are calculated from `guild_trader_listings` at query time.

--- a/backend/data-pipeline/parse_esotrade_addon.py
+++ b/backend/data-pipeline/parse_esotrade_addon.py
@@ -12,6 +12,7 @@ import re
 import sqlite3
 import json
 import time
+import urllib.error
 import urllib.request
 import ssl
 
@@ -143,6 +144,8 @@ def reset_esotrade_scans_on_disk(file_path):
             idx += 1
 
         if depth == 0:
+            if not content[brace_start + 1:idx - 1].strip():
+                return False
             new_content = content[:brace_start] + "{}" + content[idx:]
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(new_content)
@@ -151,6 +154,18 @@ def reset_esotrade_scans_on_disk(file_path):
     except Exception as e:
         print(f"[ESOTrade Auto-Clear Warning] Could not reset Scans in {os.path.basename(file_path)}: {e}")
     return False
+
+
+def report_api_error(operation, error):
+    """Report actionable API failures without exposing authentication tokens."""
+    if isinstance(error, urllib.error.HTTPError) and error.code == 401:
+        print(f"  [Notice] {operation} skipped: API token is missing or unauthorized. "
+              "Set a current ESOTRADE_AUTH_TOKEN before restarting the watcher.")
+    elif isinstance(error, urllib.error.HTTPError) and error.code == 429:
+        print(f"  [Notice] {operation} skipped: API rate limit reached. "
+              "Wait for the limit to reset before restarting the watcher.")
+    else:
+        print(f"  [Notice] {operation} skipped: {error}")
 
 def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
     sv_file = file_path or find_esotrade_savedvars()
@@ -161,6 +176,8 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
     print(f"Reading custom ESOTrade SavedVariables from: {sv_file}...")
     with open(sv_file, "r", encoding="utf-8", errors="ignore") as f:
         content = f.read()
+
+    auth_token = os.environ.get("ESOTRADE_AUTH_TOKEN")
 
     # Extract Scanner Character Metadata Header
     m_name = re.search(r'\["PlayerName"\]\s*=\s*"([^"]+)"', content)
@@ -549,7 +566,8 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
 
         # Push to central server API endpoint in 500-item chunks
         batch_size = 500
-        for b_idx in range(0, len(listings), batch_size):
+        listing_batches = range(0, len(listings), batch_size) if auth_token else ()
+        for b_idx in listing_batches:
             chunk = listings[b_idx:b_idx + batch_size]
             try:
                 payload = {
@@ -561,10 +579,10 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
                     "player_alliance": player_alliance,
                     "master_crafter": master_crafter
                 }
-                auth_token = os.environ.get("ESOTRADE_AUTH_TOKEN")
-                headers = {"Content-Type": "application/json"}
-                if auth_token:
-                    headers["Authorization"] = f"Bearer {auth_token}"
+                headers = {
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {auth_token}"
+                }
                 req = urllib.request.Request(
                     f"{server_url}/api/market/upload-scans",
                     data=json.dumps(payload).encode('utf-8'),
@@ -574,7 +592,7 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
                     res_data = json.loads(r.read().decode('utf-8'))
                     print(f"  [API Batch {b_idx//batch_size + 1}] Pushed {len(chunk)} items ({res_data.get('message')})")
             except Exception as e:
-                print(f"  [Notice] API Push Batch {b_idx//batch_size + 1} skipped:", e)
+                report_api_error(f"API Push Batch {b_idx//batch_size + 1}", e)
 
         # Parse Gear loadout if exported by ESOTrade.lua (for API push)
         gear_items = []
@@ -653,16 +671,16 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
                             "weapon_power": int(pow_m.group(1)) if pow_m else 0
                         })
 
-        if gear_items and player_name:
+        if gear_items and player_name and auth_token:
             try:
                 gear_payload = {
                     "character_name": player_name,
                     "gear": gear_items
                 }
-                auth_token = os.environ.get("ESOTRADE_AUTH_TOKEN")
-                headers = {"Content-Type": "application/json"}
-                if auth_token:
-                    headers["Authorization"] = f"Bearer {auth_token}"
+                headers = {
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {auth_token}"
+                }
                 g_req = urllib.request.Request(
                     f"{server_url}/api/characters/upload-gear",
                     data=json.dumps(gear_payload).encode('utf-8'),
@@ -672,18 +690,18 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
                     g_data = json.loads(g_res.read().decode('utf-8'))
                     print(f"  [API Gear Sync] Synced {len(gear_items)} equipped gear slots for {player_name}!")
             except Exception as ge:
-                print("  [Notice] API Gear Push skipped:", ge)
+                report_api_error("API Gear Push", ge)
 
-        if trait_items and player_name:
+        if trait_items and player_name and auth_token:
             try:
                 traits_payload = {
                     "character_name": player_name,
                     "traits": trait_items
                 }
-                auth_token = os.environ.get("ESOTRADE_AUTH_TOKEN")
-                headers = {"Content-Type": "application/json"}
-                if auth_token:
-                    headers["Authorization"] = f"Bearer {auth_token}"
+                headers = {
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {auth_token}"
+                }
                 t_req = urllib.request.Request(
                     f"{server_url}/api/characters/upload-traits",
                     data=json.dumps(traits_payload).encode('utf-8'),
@@ -693,7 +711,11 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
                     t_data = json.loads(t_res.read().decode('utf-8'))
                     print(f"  [API Trait Sync] Synced {len(trait_items)} trait nodes for {player_name}!")
             except Exception as te:
-                print("  [Notice] API Trait Push skipped:", te)
+                report_api_error("API Trait Push", te)
+
+        if not auth_token and (listings or gear_items or trait_items):
+            print("  [Notice] Remote API sync skipped: ESOTRADE_AUTH_TOKEN is not configured. "
+                  "Local SQLite synchronization completed.")
 
         print(f"SUCCESS! Ingested {len(listings)} custom ESOTrade listings into database!")
 

--- a/backend/data-pipeline/test_watcher.py
+++ b/backend/data-pipeline/test_watcher.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Regression tests for ESOTrade SavedVariables watcher feedback handling."""
+
+import io
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import parse_esotrade_addon
+import watcher
+
+
+class WatcherFeedbackLoopTests(unittest.TestCase):
+    def test_parser_does_not_rewrite_an_empty_scans_table(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            saved_variables = os.path.join(temp_dir, "ESOTrade.lua")
+            original = 'ESOTrade_SavedVariables = {\n    ["Scans"] = {\n    },\n    ["PlayerName"] = "TestHero",\n}\n'
+            with open(saved_variables, "w", encoding="utf-8") as handle:
+                handle.write(original)
+
+            modified_before = os.stat(saved_variables).st_mtime_ns
+            self.assertFalse(parse_esotrade_addon.reset_esotrade_scans_on_disk(saved_variables))
+            self.assertEqual(modified_before, os.stat(saved_variables).st_mtime_ns)
+            with open(saved_variables, "r", encoding="utf-8") as handle:
+                self.assertEqual(original, handle.read())
+
+    def test_parser_clears_nonempty_scans_without_touching_other_data(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            saved_variables = os.path.join(temp_dir, "ESOTrade.lua")
+            original = (
+                'ESOTrade_SavedVariables = {\n'
+                '    ["Scans"] = {\n'
+                '        [1] = { ["ItemId"] = 123, ["Price"] = 100 },\n'
+                '    },\n'
+                '    ["PlayerName"] = "TestHero",\n'
+                '}\n'
+            )
+            with open(saved_variables, "w", encoding="utf-8") as handle:
+                handle.write(original)
+
+            self.assertTrue(parse_esotrade_addon.reset_esotrade_scans_on_disk(saved_variables))
+            with open(saved_variables, "r", encoding="utf-8") as handle:
+                cleared = handle.read()
+            self.assertIn('["Scans"] = {}', cleared)
+            self.assertIn('["PlayerName"] = "TestHero"', cleared)
+            self.assertNotIn('["ItemId"] = 123', cleared)
+
+    def test_watcher_ignores_parser_write_but_detects_next_external_write(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            saved_variables = os.path.join(temp_dir, "ESOTrade.lua")
+            with open(saved_variables, "w", encoding="utf-8") as handle:
+                handle.write('["Scans"] = { [1] = {} }\n')
+
+            ingested_paths = []
+
+            def fake_ingest(path):
+                ingested_paths.append(path)
+                with open(path, "w", encoding="utf-8") as handle:
+                    handle.write('["Scans"] = {}\n')
+
+            last_mtimes = {}
+            self.assertTrue(watcher.process_saved_variables_change(saved_variables, last_mtimes, fake_ingest))
+            self.assertFalse(watcher.process_saved_variables_change(saved_variables, last_mtimes, fake_ingest))
+            self.assertEqual([saved_variables], ingested_paths)
+
+            previous_mtime = os.stat(saved_variables).st_mtime_ns
+            with open(saved_variables, "w", encoding="utf-8") as handle:
+                handle.write('["Scans"] = { [2] = {} }\n')
+            os.utime(saved_variables, ns=(previous_mtime + 1_000_000, previous_mtime + 1_000_000))
+
+            self.assertTrue(watcher.process_saved_variables_change(saved_variables, last_mtimes, fake_ingest))
+            self.assertEqual([saved_variables, saved_variables], ingested_paths)
+            self.assertFalse(watcher.process_saved_variables_change(saved_variables, last_mtimes, fake_ingest))
+            self.assertEqual([saved_variables, saved_variables], ingested_paths)
+
+    def test_missing_auth_token_does_not_make_api_requests(self):
+        class FakeCursor:
+            def execute(self, *_args, **_kwargs):
+                return self
+
+            def fetchall(self):
+                return []
+
+            def fetchone(self):
+                return (1,)
+
+        class FakeConnection:
+            def __init__(self):
+                self.cursor_instance = FakeCursor()
+
+            def cursor(self):
+                return self.cursor_instance
+
+            def commit(self):
+                return None
+
+            def close(self):
+                return None
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            saved_variables = os.path.join(temp_dir, "ESOTrade.lua")
+            content = (
+                'ESOTrade_SavedVariables = {\n'
+                '    ["PlayerName"] = "TestHero",\n'
+                '    ["Scans"] = {},\n'
+                '    ["Gear"] = {\n'
+                '        [1] = { ["Slot"] = 0, ["Name"] = "Test Sword" },\n'
+                '    },\n'
+                '}\n'
+            )
+            with open(saved_variables, "w", encoding="utf-8") as handle:
+                handle.write(content)
+
+            output = io.StringIO()
+            with mock.patch.dict(os.environ, {"ESOTRADE_AUTH_TOKEN": ""}), \
+                    mock.patch.object(parse_esotrade_addon.sqlite3, "connect", return_value=FakeConnection()), \
+                    mock.patch.object(parse_esotrade_addon.urllib.request, "urlopen") as urlopen, \
+                    mock.patch("sys.stdout", output):
+                parse_esotrade_addon.parse_and_sync_esotrade(saved_variables)
+
+            urlopen.assert_not_called()
+            self.assertIn("Remote API sync skipped: ESOTRADE_AUTH_TOKEN is not configured", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/data-pipeline/watcher.py
+++ b/backend/data-pipeline/watcher.py
@@ -47,6 +47,30 @@ def ingest(path):
         print(f"Native parser exited with status {result.returncode}.")
 
 
+def process_saved_variables_change(path, last_mtimes, ingest_func=ingest):
+    """Ingest one external file change and ignore any write made by the parser."""
+    try:
+        modified_at = os.stat(path).st_mtime_ns
+    except FileNotFoundError:
+        last_mtimes.pop(path, None)
+        return False
+
+    if last_mtimes.get(path) == modified_at:
+        return False
+
+    last_mtimes[path] = modified_at
+    try:
+        ingest_func(path)
+    finally:
+        # parse_esotrade_addon.py may clear the Scans table after a successful
+        # import. Record that post-ingestion write so it cannot trigger a loop.
+        try:
+            last_mtimes[path] = os.stat(path).st_mtime_ns
+        except FileNotFoundError:
+            last_mtimes.pop(path, None)
+    return True
+
+
 def start_watching(poll_interval=2, purge_interval=PURGE_INTERVAL_SECONDS):
     print("======================================================")
     print("=== ESOTrade SavedVariables Watcher ===")
@@ -64,12 +88,7 @@ def start_watching(poll_interval=2, purge_interval=PURGE_INTERVAL_SECONDS):
                 last_purge_time = current_time
 
             for saved_variables_path in WATCH_PATHS:
-                if not os.path.exists(saved_variables_path):
-                    continue
-                modified_at = os.path.getmtime(saved_variables_path)
-                if saved_variables_path not in last_mtimes or modified_at > last_mtimes[saved_variables_path]:
-                    last_mtimes[saved_variables_path] = modified_at
-                    ingest(saved_variables_path)
+                process_saved_variables_change(saved_variables_path, last_mtimes)
 
             time.sleep(poll_interval)
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
Fixes the desktop SavedVariables watcher feedback loop reported in #113.

## Problem
`watcher.py` stored the pre-parser modification time. The parser then rewrote `ESOTrade.lua` while clearing `Scans`, causing the watcher to treat its own write as another game event. Because the parser also rewrote an already-empty table, this repeated forever, resynchronized unchanged character data, retried unauthorized gear/trait API calls, and eventually hit HTTP 429 rate limiting.

## Changes
- record the post-ingestion SavedVariables timestamp so parser-owned cleanup is ignored
- avoid rewriting an already-empty `Scans` table
- skip authenticated API requests entirely when `ESOTRADE_AUTH_TOKEN` is absent while preserving local SQLite synchronization
- provide actionable, token-safe messages for HTTP 401 and 429 failures
- add four regression tests for empty-table no-op behavior, nonempty cleanup, self-write suppression, later external changes, and missing-token network suppression
- run the watcher regression suite in GitHub CI and document token behavior

## Verification
- `python -m py_compile watcher.py parse_esotrade_addon.py test_watcher.py`
- `python validate_items.py` — 155,476 items validated
- `python test_db_queries.py`
- `python test_watcher.py` — 4 tests passed
- `cd backend && npm test` — 55 endpoint suites plus bcrypt migration regressions passed
- `cd frontend && npm run build`
- live empty `ESOTrade.lua` check: reset returned false and file timestamp remained unchanged

Fixes #113