### PR TITLE
[Draft] Fix #115: Commit native parser SQLite synchronization

### DIFF
--- a/backend/data-pipeline/parse_esotrade_addon.py
+++ b/backend/data-pipeline/parse_esotrade_addon.py
@@ -167,6 +167,23 @@ def report_api_error(operation, error):
     else:
         print(f"  [Notice] {operation} skipped: {error}")
 
+
+def commit_local_sync(connection):
+    """Commit parsed native data atomically, rolling back on SQLite failure."""
+    try:
+        connection.commit()
+    except sqlite3.Error as error:
+        try:
+            connection.rollback()
+        except sqlite3.Error as rollback_error:
+            raise RuntimeError(
+                f"Local SQLite commit failed and rollback also failed: {rollback_error}"
+            ) from error
+        raise RuntimeError(
+            "Local SQLite synchronization failed; ESOTrade Scans were retained for retry."
+        ) from error
+
+
 def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
     sv_file = file_path or find_esotrade_savedvars()
     if not sv_file or not os.path.exists(sv_file):
@@ -221,6 +238,9 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
 
     conn = sqlite3.connect(DEFAULT_DB_PATH)
     cursor = conn.cursor()
+    local_sync_messages = []
+    synced_gear_count = 0
+    synced_traits_count = 0
     cursor.execute("SELECT game_item_id FROM items")
     valid_ids = set(row[0] for row in cursor.fetchall())
 
@@ -398,7 +418,9 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
         """, (player_name, player_class_name, player_level, player_alliance, master_crafter))
         alliance_map = {1: "Aldmeri Dominion", 2: "Ebonheart Pact", 3: "Daggerfall Covenant"}
         alliance_str = alliance_map.get(player_alliance, "Aldmeri Dominion")
-        print(f"Synced character '{player_name}' ({player_class_name}, Lvl {player_level}, Alliance: {alliance_str}) to roster!")
+        local_sync_messages.append(
+            f"Synced character '{player_name}' ({player_class_name}, Lvl {player_level}, Alliance: {alliance_str}) to roster!"
+        )
 
         # Sync character equipped gear loadout to character_gear table
         cursor.execute("SELECT id FROM characters WHERE name = ?", (player_name,))
@@ -486,7 +508,9 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
                         """, (char_id, slot_id, item_id, item_name, item_link, quality, trait_id, set_name, enchant_text, item_icon, trait_name, trait_desc, armor_rating, weapon_power))
                         synced_gear_count += 1
                 if synced_gear_count > 0:
-                    print(f"Synced {synced_gear_count} equipped gear items to character '{player_name}' loadout!")
+                    local_sync_messages.append(
+                        f"Synced {synced_gear_count} equipped gear items to character '{player_name}' loadout!"
+                    )
 
             # Sync character trait research if present
             trait_items = []
@@ -562,7 +586,17 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
                                 "completes_at": completes_at
                             })
                     if synced_traits_count > 0:
-                        print(f"Synced {synced_traits_count} trait research records for '{player_name}'!")
+                        local_sync_messages.append(
+                            f"Synced {synced_traits_count} trait research records for '{player_name}'!"
+                        )
+
+        try:
+            commit_local_sync(conn)
+        except RuntimeError:
+            conn.close()
+            raise
+        for message in local_sync_messages:
+            print(message)
 
         # Push to central server API endpoint in 500-item chunks
         batch_size = 500
@@ -714,13 +748,24 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
                 report_api_error("API Trait Push", te)
 
         if not auth_token and (listings or gear_items or trait_items):
-            print("  [Notice] Remote API sync skipped: ESOTRADE_AUTH_TOKEN is not configured. "
-                  "Local SQLite synchronization completed.")
+            print("  [Local sync] Data is committed to the local application database. "
+                  "No duplicate API push was attempted because ESOTRADE_AUTH_TOKEN is not configured.")
 
-        print(f"SUCCESS! Ingested {len(listings)} custom ESOTrade listings into database!")
+    if not player_name:
+        try:
+            commit_local_sync(conn)
+        except RuntimeError:
+            conn.close()
+            raise
 
-        # Automated SavedVariables Disk Flush: Cleanly reset Scans = {} in ESOTrade.lua on disk
-        reset_esotrade_scans_on_disk(sv_file)
+    print(
+        "SUCCESS! Local SQLite sync committed "
+        f"(listings={len(listings)}, characters={1 if player_name else 0}, "
+        f"gear_items={synced_gear_count}, trait_records={synced_traits_count})."
+    )
+
+    # Only clear native scans after the local transaction is durably committed.
+    reset_esotrade_scans_on_disk(sv_file)
 
     conn.close()
     return len(listings)

--- a/backend/data-pipeline/test_watcher.py
+++ b/backend/data-pipeline/test_watcher.py
@@ -3,8 +3,10 @@
 
 import io
 import os
+import sqlite3
 import tempfile
 import unittest
+from contextlib import closing
 from unittest import mock
 
 import parse_esotrade_addon
@@ -75,7 +77,116 @@ class WatcherFeedbackLoopTests(unittest.TestCase):
             self.assertEqual([saved_variables, saved_variables], ingested_paths)
 
     def test_missing_auth_token_does_not_make_api_requests(self):
-        class FakeCursor:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            saved_variables = os.path.join(temp_dir, "ESOTrade.lua")
+            database = os.path.join(temp_dir, "eso_catalog.db")
+            with closing(sqlite3.connect(database)) as connection:
+                connection.executescript("""
+                    CREATE TABLE items (game_item_id INTEGER PRIMARY KEY);
+                    INSERT INTO items (game_item_id) VALUES (123);
+                    CREATE TABLE guild_trader_listings (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        game_item_id INTEGER,
+                        item_name TEXT,
+                        server TEXT,
+                        seller_name TEXT,
+                        price INTEGER,
+                        quantity INTEGER,
+                        active_stacks INTEGER,
+                        guild_name TEXT,
+                        location TEXT,
+                        level INTEGER,
+                        quality INTEGER,
+                        trait_id INTEGER,
+                        expires_at TEXT,
+                        discovered_at TEXT,
+                        UNIQUE(game_item_id, server, guild_name, seller_name, price, quantity, level, quality, trait_id)
+                    );
+                    CREATE TABLE characters (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        user_id INTEGER,
+                        name TEXT UNIQUE,
+                        class TEXT,
+                        level INTEGER,
+                        alliance INTEGER,
+                        master_crafter_unlocked INTEGER,
+                        last_sync_at TEXT
+                    );
+                    CREATE TABLE character_gear (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        character_id INTEGER,
+                        slot_id INTEGER,
+                        game_item_id INTEGER,
+                        item_name TEXT,
+                        item_link TEXT,
+                        quality INTEGER,
+                        trait_id INTEGER,
+                        set_name TEXT,
+                        enchantment_description TEXT,
+                        item_icon TEXT,
+                        trait_name TEXT,
+                        trait_description TEXT,
+                        armor_rating INTEGER,
+                        weapon_power INTEGER,
+                        updated_at TEXT,
+                        UNIQUE(character_id, slot_id)
+                    );
+                    CREATE TABLE character_trait_research (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        character_id INTEGER,
+                        crafting_type TEXT,
+                        equipment_type TEXT,
+                        trait_id INTEGER,
+                        trait_name TEXT,
+                        research_status TEXT,
+                        started_at TEXT,
+                        completes_at TEXT,
+                        updated_at TEXT,
+                        UNIQUE(character_id, equipment_type, trait_id)
+                    );
+                """)
+            content = (
+                'ESOTrade_SavedVariables = {\n'
+                '    ["PlayerName"] = "TestHero",\n'
+                '    ["Scans"] = {\n'
+                '        [1] = { ["UID"] = "native-test-1", ["ItemId"] = 123, '
+                '["Name"] = "Native Test Item", ["Price"] = 100, ["Qty"] = 1, '
+                '["Guild"] = "Test Trading Guild", ["Seller"] = "@TestSeller" },\n'
+                '    },\n'
+                '    ["Gear"] = {\n'
+                '        [1] = { ["Slot"] = 0, ["Name"] = "Test Sword" },\n'
+                '    },\n'
+                '    ["TraitResearch"] = {\n'
+                '        [1] = { ["EquipmentType"] = "Sword", ["TraitId"] = 3, '
+                '["Status"] = "COMPLETED", ["CraftingType"] = "Blacksmithing" },\n'
+                '    },\n'
+                '}\n'
+            )
+            with open(saved_variables, "w", encoding="utf-8") as handle:
+                handle.write(content)
+
+            output = io.StringIO()
+            with mock.patch.dict(os.environ, {"ESOTRADE_AUTH_TOKEN": ""}), \
+                    mock.patch.object(parse_esotrade_addon, "DEFAULT_DB_PATH", database), \
+                    mock.patch.object(parse_esotrade_addon.urllib.request, "urlopen") as urlopen, \
+                    mock.patch("sys.stdout", output):
+                parse_esotrade_addon.parse_and_sync_esotrade(saved_variables)
+
+            urlopen.assert_not_called()
+            self.assertIn("Data is committed to the local application database", output.getvalue())
+            self.assertIn(
+                "SUCCESS! Local SQLite sync committed "
+                "(listings=1, characters=1, gear_items=1, trait_records=1)",
+                output.getvalue()
+            )
+            with closing(sqlite3.connect(database)) as verification:
+                self.assertEqual(1, verification.execute("SELECT COUNT(*) FROM characters").fetchone()[0])
+                self.assertEqual(1, verification.execute("SELECT COUNT(*) FROM character_gear").fetchone()[0])
+                self.assertEqual(1, verification.execute("SELECT COUNT(*) FROM character_trait_research").fetchone()[0])
+                self.assertEqual(1, verification.execute("SELECT COUNT(*) FROM guild_trader_listings").fetchone()[0])
+
+    def test_commit_failure_rolls_back_and_retains_scans(self):
+        class FailingCursor:
             def execute(self, *_args, **_kwargs):
                 return self
 
@@ -85,42 +196,45 @@ class WatcherFeedbackLoopTests(unittest.TestCase):
             def fetchone(self):
                 return (1,)
 
-        class FakeConnection:
+        class FailingConnection:
             def __init__(self):
-                self.cursor_instance = FakeCursor()
+                self.cursor_instance = FailingCursor()
+                self.rolled_back = False
+                self.closed = False
 
             def cursor(self):
                 return self.cursor_instance
 
             def commit(self):
-                return None
+                raise sqlite3.OperationalError("simulated commit failure")
+
+            def rollback(self):
+                self.rolled_back = True
 
             def close(self):
-                return None
+                self.closed = True
 
         with tempfile.TemporaryDirectory() as temp_dir:
             saved_variables = os.path.join(temp_dir, "ESOTrade.lua")
             content = (
                 'ESOTrade_SavedVariables = {\n'
                 '    ["PlayerName"] = "TestHero",\n'
-                '    ["Scans"] = {},\n'
-                '    ["Gear"] = {\n'
-                '        [1] = { ["Slot"] = 0, ["Name"] = "Test Sword" },\n'
-                '    },\n'
+                '    ["Scans"] = { [1] = { ["ItemId"] = 123, ["Price"] = 100 } },\n'
                 '}\n'
             )
             with open(saved_variables, "w", encoding="utf-8") as handle:
                 handle.write(content)
 
-            output = io.StringIO()
-            with mock.patch.dict(os.environ, {"ESOTRADE_AUTH_TOKEN": ""}), \
-                    mock.patch.object(parse_esotrade_addon.sqlite3, "connect", return_value=FakeConnection()), \
-                    mock.patch.object(parse_esotrade_addon.urllib.request, "urlopen") as urlopen, \
-                    mock.patch("sys.stdout", output):
-                parse_esotrade_addon.parse_and_sync_esotrade(saved_variables)
+            connection = FailingConnection()
+            with mock.patch.object(parse_esotrade_addon.sqlite3, "connect", return_value=connection), \
+                    mock.patch.dict(os.environ, {"ESOTRADE_AUTH_TOKEN": ""}):
+                with self.assertRaisesRegex(RuntimeError, "Scans were retained for retry"):
+                    parse_esotrade_addon.parse_and_sync_esotrade(saved_variables)
 
-            urlopen.assert_not_called()
-            self.assertIn("Remote API sync skipped: ESOTRADE_AUTH_TOKEN is not configured", output.getvalue())
+            self.assertTrue(connection.rolled_back)
+            self.assertTrue(connection.closed)
+            with open(saved_variables, "r", encoding="utf-8") as handle:
+                self.assertEqual(content, handle.read())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fixes #115 by durably committing native parser SQLite mutations before any optional API synchronization and before reporting success.

## Problem
The parser inserted or updated listings, characters, equipped gear, and trait research but never called `conn.commit()`. Closing the connection rolled back those changes. When `ESOTRADE_AUTH_TOKEN` was absent, the optional API path was also skipped, so the log claimed successful synchronization while the application remained empty.

## Changes
- atomically commit local SQLite mutations before optional HTTP synchronization
- roll back on commit failure and retain `Scans` on disk for retry
- defer character/gear/trait success messages until the commit succeeds
- make the final success line report committed listing, character, gear, and trait counts
- clarify that an absent API token only suppresses a redundant remote push; local application data is committed
- extend regression coverage with a real temporary SQLite database and a separate verification connection
- add a simulated commit-failure regression covering rollback, connection cleanup, and scan retention

## Verification
- `python -m py_compile parse_esotrade_addon.py test_watcher.py`
- `python validate_items.py` — 155,476 items validated
- `python test_db_queries.py`
- `python test_watcher.py` — 5 tests passed
- `cd backend && npm test` — 55 endpoint suites plus bcrypt migration regressions passed
- `cd frontend && npm run build`
- live SavedVariables import verified through both a separate SQLite connection and authenticated `GET /api/characters`: `Summonerofthedead`, 12 gear rows, 324 trait rows

Fixes #115