### PR TITLE
[MODERATE] Make schema migrations and transaction rollbacks observable and failure-safe

### DIFF
--- a/addon/ESOTrade/ESOTrade.lua
+++ b/addon/ESOTrade/ESOTrade.lua
@@ -1,5 +1,5 @@
 -- ============================================================================
--- ESO Trade Addon v1.6 (Attribute-Aware Native In-Game Kiosk & Gear Scanner)
+-- ESO Trade Addon v1.6.1 (Attribute-Aware Native In-Game Kiosk & Gear Scanner)
 -- Captures 100% real Item ID, Level, Quality, Trait, Guild, Location, and Equipped Gear.
 -- ============================================================================
 
@@ -50,6 +50,24 @@ local function ParseItemLinkAttributes(itemLink)
     local parsedTrait = tonumber(trait) or 0
 
     return parsedId, parsedLevel, parsedQuality, parsedTrait
+end
+
+-- Preserve ESO's stable per-listing identity so repeated trading-house response
+-- events can be distinguished from genuinely separate identical stacks.
+local function NormalizeTradingHouseUid(uid)
+    if uid == nil then return "" end
+
+    local normalizedUid
+    if Id64ToString then
+        normalizedUid = Id64ToString(uid)
+    else
+        normalizedUid = tostring(uid)
+    end
+
+    if not normalizedUid or normalizedUid == "" or normalizedUid == "0" then
+        return ""
+    end
+    return normalizedUid
 end
 
 -- Export equipped gear loadout for the active character
@@ -207,6 +225,7 @@ local function OnTradingHouseResponse(eventCode, responseType, result)
             end
             
             table.insert(ESOTradeVars.Scans, {
+                UID      = NormalizeTradingHouseUid(uid),
                 ItemId   = itemId,
                 Link     = itemLink,
                 Name     = name,
@@ -298,7 +317,7 @@ local function OnAddOnLoaded(eventCode, addOnName)
     EVENT_MANAGER:RegisterForEvent(ESOTrade.name, EVENT_SMITHING_TRAIT_RESEARCH_COMPLETED, RefreshCharacterData)
     EVENT_MANAGER:RegisterForEvent(ESOTrade.name, EVENT_SMITHING_TRAIT_RESEARCH_STARTED, RefreshCharacterData)
 
-    d("|c00FF00[ESOTrade Addon v1.6 Loaded]|r Automatic metadata, gear & trait research sync active for character '" .. (ESOTradeVars.PlayerName or "Hero") .. "' on " .. (GetWorldName() or "NA"))
+    d("|c00FF00[ESOTrade Addon v1.6.1 Loaded]|r Automatic metadata, gear & trait research sync active for character '" .. (ESOTradeVars.PlayerName or "Hero") .. "' on " .. (GetWorldName() or "NA"))
 end
 
 EVENT_MANAGER:RegisterForEvent(ESOTrade.name, EVENT_ADD_ON_LOADED, OnAddOnLoaded)

--- a/addon/ESOTrade/ESOTrade.lua
+++ b/addon/ESOTrade/ESOTrade.lua
@@ -1,5 +1,5 @@
 -- ============================================================================
--- ESO Trade Addon v1.6.1 (Attribute-Aware Native In-Game Kiosk & Gear Scanner)
+-- ESO Trade Addon v1.6.2 (Attribute-Aware Native In-Game Kiosk & Gear Scanner)
 -- Captures 100% real Item ID, Level, Quality, Trait, Guild, Location, and Equipped Gear.
 -- ============================================================================
 
@@ -68,6 +68,56 @@ local function NormalizeTradingHouseUid(uid)
         return ""
     end
     return normalizedUid
+end
+
+-- Rebuild an in-memory UID lookup after login or /reloadui. This also compacts
+-- repeated UID-bearing entries that may already be present in SavedVariables.
+-- Legacy entries without an identity are unsafe to count because the old event
+-- handler may have captured the same visible page more than once.
+local function RebuildTradingHouseScanIndex()
+    local compactedScans = {}
+    local positionsByUid = {}
+    local discardedLegacyScanCount = 0
+
+    for _, scan in ipairs(ESOTradeVars.Scans or {}) do
+        local uid = scan and scan.UID and tostring(scan.UID) or ""
+        if uid ~= "" and uid ~= "0" then
+            local existingPosition = positionsByUid[uid]
+            if existingPosition then
+                compactedScans[existingPosition] = scan
+            else
+                table.insert(compactedScans, scan)
+                positionsByUid[uid] = #compactedScans
+            end
+        else
+            discardedLegacyScanCount = discardedLegacyScanCount + 1
+        end
+    end
+
+    ESOTradeVars.Scans = compactedScans
+    ESOTrade.scanPositionsByUid = positionsByUid
+    return discardedLegacyScanCount
+end
+
+-- Store each real guild-trader listing once. A repeated callback or reload can
+-- refresh the observation, but cannot create another stack for the same UID.
+local function StoreTradingHouseScan(scan)
+    ESOTrade.scanPositionsByUid = ESOTrade.scanPositionsByUid or {}
+
+    local uid = scan and scan.UID or ""
+    if uid == "" or uid == "0" then
+        return nil
+    end
+
+    local existingPosition = ESOTrade.scanPositionsByUid[uid]
+    if existingPosition then
+        ESOTradeVars.Scans[existingPosition] = scan
+        return false
+    end
+
+    table.insert(ESOTradeVars.Scans, scan)
+    ESOTrade.scanPositionsByUid[uid] = #ESOTradeVars.Scans
+    return true
 end
 
 -- Export equipped gear loadout for the active character
@@ -189,6 +239,13 @@ end
 
 -- Callback: Fired when Trading House (Guild Trader) search/browse data arrives from ESO server
 local function OnTradingHouseResponse(eventCode, responseType, result)
+    -- Text/name lookup, purchase, post, and listings-management responses can
+    -- arrive while the previous search page remains readable. Only consume a
+    -- successfully completed search response or that stale page is duplicated.
+    if responseType ~= TRADING_HOUSE_RESULT_SEARCH_PENDING or result ~= TRADING_HOUSE_RESULT_SUCCESS then
+        return
+    end
+
     local numItemsOnPage, currentPage, hasMorePages = GetTradingHouseSearchResultsInfo()
     if not numItemsOnPage or numItemsOnPage <= 0 then return end
 
@@ -213,6 +270,8 @@ local function OnTradingHouseResponse(eventCode, responseType, result)
 
     local now = GetTimeStamp()
     local newScanCount = 0
+    local refreshedScanCount = 0
+    local skippedScanCount = 0
 
     for i = 1, numItemsOnPage do
         local itemLink = GetTradingHouseSearchResultItemLink(i)
@@ -224,7 +283,7 @@ local function OnTradingHouseResponse(eventCode, responseType, result)
                 itemQuality = quality or 1
             end
             
-            table.insert(ESOTradeVars.Scans, {
+            local scan = {
                 UID      = NormalizeTradingHouseUid(uid),
                 ItemId   = itemId,
                 Link     = itemLink,
@@ -239,13 +298,24 @@ local function OnTradingHouseResponse(eventCode, responseType, result)
                 Location = locationName,
                 Scanner  = GetUnitName("player") or "Hero",
                 Time     = now
-            })
-            newScanCount = newScanCount + 1
+            }
+
+            local storeResult = StoreTradingHouseScan(scan)
+            if storeResult == true then
+                newScanCount = newScanCount + 1
+            elseif storeResult == false then
+                refreshedScanCount = refreshedScanCount + 1
+            else
+                skippedScanCount = skippedScanCount + 1
+            end
         end
     end
 
-    if newScanCount > 0 then
-        d("|c00FF00[ESOTrade]|r Automatically Scanned & Logged " .. newScanCount .. " active listings from '" .. guildName .. "' (" .. locationName .. ")!")
+    if newScanCount > 0 or refreshedScanCount > 0 then
+        d("|c00FF00[ESOTrade]|r Captured " .. (newScanCount + refreshedScanCount) .. " active listings from '" .. guildName .. "' (" .. newScanCount .. " new, " .. refreshedScanCount .. " refreshed).")
+    end
+    if skippedScanCount > 0 then
+        d("|cFFFF00[ESOTrade]|r Skipped " .. skippedScanCount .. " result(s) without a stable listing UID to prevent false stack counts.")
     end
 end
 
@@ -266,6 +336,11 @@ local function OnAddOnLoaded(eventCode, addOnName)
     if addOnName ~= ESOTrade.name then return end
     EVENT_MANAGER:UnregisterForEvent(ESOTrade.name, EVENT_ADD_ON_LOADED)
 
+    local discardedLegacyScanCount = RebuildTradingHouseScanIndex()
+    if discardedLegacyScanCount > 0 then
+        d("|cFFFF00[ESOTrade]|r Removed " .. discardedLegacyScanCount .. " legacy scan record(s) without listing UIDs. Revisit the trader to capture clean results.")
+    end
+
     -- Register for Trading House response event
     EVENT_MANAGER:RegisterForEvent(ESOTrade.name, EVENT_TRADING_HOUSE_RESPONSE_RECEIVED, OnTradingHouseResponse)
 
@@ -276,6 +351,7 @@ local function OnAddOnLoaded(eventCode, addOnName)
         if option == "clear" or option == "reset" then
             local count = #(ESOTradeVars.Scans or {})
             ESOTradeVars.Scans = {}
+            ESOTrade.scanPositionsByUid = {}
             d("|c00FF00[ESOTrade]|r Cleared " .. count .. " scanned items from SavedVariables memory.")
         elseif option == "status" then
             local count = #(ESOTradeVars.Scans or {})
@@ -317,7 +393,7 @@ local function OnAddOnLoaded(eventCode, addOnName)
     EVENT_MANAGER:RegisterForEvent(ESOTrade.name, EVENT_SMITHING_TRAIT_RESEARCH_COMPLETED, RefreshCharacterData)
     EVENT_MANAGER:RegisterForEvent(ESOTrade.name, EVENT_SMITHING_TRAIT_RESEARCH_STARTED, RefreshCharacterData)
 
-    d("|c00FF00[ESOTrade Addon v1.6.1 Loaded]|r Automatic metadata, gear & trait research sync active for character '" .. (ESOTradeVars.PlayerName or "Hero") .. "' on " .. (GetWorldName() or "NA"))
+    d("|c00FF00[ESOTrade Addon v1.6.2 Loaded]|r Automatic metadata, gear & trait research sync active for character '" .. (ESOTradeVars.PlayerName or "Hero") .. "' on " .. (GetWorldName() or "NA"))
 end
 
 EVENT_MANAGER:RegisterForEvent(ESOTrade.name, EVENT_ADD_ON_LOADED, OnAddOnLoaded)

--- a/addon/ESOTrade/ESOTrade.txt
+++ b/addon/ESOTrade/ESOTrade.txt
@@ -1,6 +1,6 @@
 ## Title: ESO Trade Addon
 ## APIVersion: 101044 101045
-## Version: 1.6.1
+## Version: 1.6.2
 ## Author: ESO Trade Project
 ## Description: Real-time guild trader kiosk auto-logger & character gear loadout exporter
 ## SavedVariables: ESOTradeVars

--- a/addon/ESOTrade/ESOTrade.txt
+++ b/addon/ESOTrade/ESOTrade.txt
@@ -1,6 +1,6 @@
 ## Title: ESO Trade Addon
 ## APIVersion: 101044 101045
-## Version: 1.6.0
+## Version: 1.6.1
 ## Author: ESO Trade Project
 ## Description: Real-time guild trader kiosk auto-logger & character gear loadout exporter
 ## SavedVariables: ESOTradeVars

--- a/backend/data-pipeline/parse_esotrade_addon.py
+++ b/backend/data-pipeline/parse_esotrade_addon.py
@@ -336,15 +336,19 @@ def parse_and_sync_esotrade(file_path=None, server_url="http://localhost:5001"):
             session_cluster_items.append(item)
 
     # Step 4: UID Set Deduplication & Grouping within the Session Cluster Window
-    seen_uids_in_session = set()
+    uid_positions_in_session = {}
     unique_items_in_session = []
 
     for item in session_cluster_items:
         uid = item["uid"]
-        if uid and uid != "":
-            if uid in seen_uids_in_session:
-                continue # Skip duplicate re-searched UID within the session cluster
-            seen_uids_in_session.add(uid)
+        if uid and uid != "0":
+            existing_position = uid_positions_in_session.get(uid)
+            if existing_position is not None:
+                # A response callback may repeat the same result page. Replace
+                # the older observation without increasing the stack count.
+                unique_items_in_session[existing_position] = item
+                continue
+            uid_positions_in_session[uid] = len(unique_items_in_session)
         unique_items_in_session.append(item)
 
     # Step 5: Group unique items by seller listing key to compute active_stacks

--- a/backend/data-pipeline/test_api_endpoints.js
+++ b/backend/data-pipeline/test_api_endpoints.js
@@ -4,6 +4,11 @@ const crypto = require('crypto');
 const { spawn } = require('child_process');
 const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
+const {
+    createSchemaMigrationRunner,
+    isExpectedDuplicateColumnError,
+    rollbackTransaction
+} = require('../database_helpers');
 
 const PORT = 5002;
 const SERVER_PATH = path.join(__dirname, '..', 'server.js');
@@ -204,7 +209,99 @@ function testDbAll(sql, params = []) {
     });
 }
 
+function closeDatabase(database) {
+    return new Promise((resolve, reject) => {
+        database.close((closeErr) => {
+            if (closeErr) reject(closeErr);
+            else resolve();
+        });
+    });
+}
+
+async function testDatabaseFailureHandling() {
+    console.log("\n0a. Testing migration idempotency and failure diagnostics...");
+    const migrationDb = new sqlite3.Database(':memory:');
+    const infoMessages = [];
+    const errorMessages = [];
+    const failures = [];
+    const logger = {
+        info: (message) => infoMessages.push(message),
+        error: (message) => errorMessages.push(message)
+    };
+    const runMigration = createSchemaMigrationRunner(migrationDb, {
+        logger,
+        onUnexpectedError: (failure) => failures.push(failure)
+    });
+
+    try {
+        await runMigration(
+            'migration-probe.create-column',
+            'CREATE TABLE migration_probe (existing_column INTEGER);'
+        );
+        const duplicateResult = await runMigration(
+            'migration-probe.add-existing-column',
+            'ALTER TABLE migration_probe ADD COLUMN existing_column INTEGER;',
+            { allowDuplicateColumn: true }
+        );
+        if (duplicateResult.status !== 'already-applied' || failures.length !== 0) {
+            throw new Error(`Expected matching duplicate column to be idempotent, got ${JSON.stringify(duplicateResult)}`);
+        }
+        if (!infoMessages.some((message) => message.includes('migration-probe.add-existing-column') && message.includes('existing_column'))) {
+            throw new Error('Expected duplicate-column migration to emit a named idempotency diagnostic.');
+        }
+        const mismatchedDuplicate = Object.assign(
+            new Error('SQLITE_ERROR: duplicate column name: unrelated_column'),
+            { code: 'SQLITE_ERROR', errno: 1 }
+        );
+        if (isExpectedDuplicateColumnError(
+            mismatchedDuplicate,
+            'ALTER TABLE migration_probe ADD COLUMN existing_column INTEGER;'
+        )) {
+            throw new Error('A duplicate-column error for the wrong column was incorrectly suppressed.');
+        }
+
+        const failureResult = await runMigration(
+            'migration-probe.missing-table',
+            'ALTER TABLE missing_migration_probe ADD COLUMN new_column TEXT;',
+            { allowDuplicateColumn: true }
+        );
+        if (failureResult.status !== 'failed' || failures.length !== 1) {
+            throw new Error(`Expected unexpected migration failure to be reported, got ${JSON.stringify(failureResult)}`);
+        }
+        const unexpectedLog = errorMessages.find((message) => message.includes('migration-probe.missing-table')) || '';
+        if (!unexpectedLog.includes('code=SQLITE_ERROR') || !unexpectedLog.includes('Statement: ALTER TABLE missing_migration_probe')) {
+            throw new Error(`Unexpected migration diagnostic lacked SQLite or statement context: ${unexpectedLog}`);
+        }
+
+        const rollbackLogs = [];
+        const originalError = Object.assign(new Error('request write failed'), { code: 'SQLITE_CONSTRAINT', errno: 19 });
+        const rollbackError = Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY', errno: 5 });
+        const rollbackSucceeded = await rollbackTransaction(
+            async () => { throw rollbackError; },
+            'Regression test transaction',
+            originalError,
+            { error: (message) => rollbackLogs.push(message) }
+        );
+        if (rollbackSucceeded || rollbackLogs.length !== 1) {
+            throw new Error('Rollback failure was not reported exactly once.');
+        }
+        const rollbackLog = rollbackLogs[0];
+        if (!rollbackLog.includes('Regression test transaction')
+            || !rollbackLog.includes('SQLITE_CONSTRAINT')
+            || !rollbackLog.includes('request write failed')
+            || !rollbackLog.includes('SQLITE_BUSY')
+            || !rollbackLog.includes('database is locked')) {
+            throw new Error(`Rollback diagnostic did not preserve both errors: ${rollbackLog}`);
+        }
+    } finally {
+        await closeDatabase(migrationDb);
+    }
+
+    console.log("   Duplicate columns remain idempotent; unexpected migrations and rollback failures retain full context.");
+}
+
 async function runTests() {
+    await testDatabaseFailureHandling();
     await seedPreMigrationLegacyAccount();
     serverProcess = startTestServer();
 
@@ -1181,7 +1278,7 @@ async function runTests() {
         }
         console.log("   Saved-search create/list/pin/delete behavior and cross-account isolation verified!");
 
-        console.log("\nAll 55 API endpoint suites plus bcrypt migration regressions passed successfully!");
+        console.log("\nAll 55 API endpoint suites plus bcrypt, schema-migration, and rollback regressions passed successfully!");
     } catch (err) {
         console.error("API test failed:", err);
         process.exitCode = 1;

--- a/backend/data-pipeline/test_watcher.py
+++ b/backend/data-pipeline/test_watcher.py
@@ -15,13 +15,22 @@ import watcher
 
 
 class WatcherFeedbackLoopTests(unittest.TestCase):
-    def test_listing_uids_keep_identical_stack_counts_idempotent(self):
+    def test_listing_uids_keep_three_identical_stack_counts_idempotent(self):
         addon_path = os.path.abspath(os.path.join(
             os.path.dirname(__file__), "..", "..", "addon", "ESOTrade", "ESOTrade.lua"
         ))
         with open(addon_path, "r", encoding="utf-8") as addon_file:
             addon_source = addon_file.read()
         self.assertIn("UID      = NormalizeTradingHouseUid(uid)", addon_source)
+        handler_source = addon_source[
+            addon_source.index("local function OnTradingHouseResponse"):addon_source.index("local function RefreshCharacterData")
+        ]
+        self.assertLess(
+            handler_source.index("responseType ~= TRADING_HOUSE_RESULT_SEARCH_PENDING"),
+            handler_source.index("GetTradingHouseSearchResultsInfo()")
+        )
+        self.assertIn("result ~= TRADING_HOUSE_RESULT_SUCCESS", handler_source)
+        self.assertIn("StoreTradingHouseScan(scan)", handler_source)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             saved_variables = os.path.join(temp_dir, "ESOTrade.lua")
@@ -52,10 +61,14 @@ class WatcherFeedbackLoopTests(unittest.TestCase):
 
             scan_time = int(time.time())
             scan_rows = []
-            for index, uid in enumerate(("listing-uid-1", "listing-uid-2", "listing-uid-1", "listing-uid-2"), 1):
+            repeated_search_page = (
+                "listing-uid-1", "listing-uid-2", "listing-uid-3",
+                "listing-uid-1", "listing-uid-2", "listing-uid-3",
+            )
+            for index, uid in enumerate(repeated_search_page, 1):
                 scan_rows.append(
                     f'        [{index}] = {{ ["UID"] = "{uid}", ["ItemId"] = 123, '
-                    f'["Name"] = "Identical Stack Item", ["Price"] = 200, ["Qty"] = 2, '
+                    f'["Name"] = "Tide-Born Feathers", ["Price"] = 210000, ["Qty"] = 100, '
                     f'["Guild"] = "Regression Test Guild", ["Seller"] = "@StackSeller", '
                     f'["Location"] = "Regression Trader", ["Level"] = 50, ["Quality"] = 4, '
                     f'["Trait"] = 3, ["Time"] = {scan_time} }},\n'
@@ -83,7 +96,7 @@ class WatcherFeedbackLoopTests(unittest.TestCase):
                     FROM guild_trader_listings
                     WHERE game_item_id = 123
                 """).fetchone()
-            self.assertEqual((2, 2), row)
+            self.assertEqual((100, 3), row)
 
     def test_parser_does_not_rewrite_an_empty_scans_table(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/backend/data-pipeline/test_watcher.py
+++ b/backend/data-pipeline/test_watcher.py
@@ -5,6 +5,7 @@ import io
 import os
 import sqlite3
 import tempfile
+import time
 import unittest
 from contextlib import closing
 from unittest import mock
@@ -14,6 +15,76 @@ import watcher
 
 
 class WatcherFeedbackLoopTests(unittest.TestCase):
+    def test_listing_uids_keep_identical_stack_counts_idempotent(self):
+        addon_path = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), "..", "..", "addon", "ESOTrade", "ESOTrade.lua"
+        ))
+        with open(addon_path, "r", encoding="utf-8") as addon_file:
+            addon_source = addon_file.read()
+        self.assertIn("UID      = NormalizeTradingHouseUid(uid)", addon_source)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            saved_variables = os.path.join(temp_dir, "ESOTrade.lua")
+            database = os.path.join(temp_dir, "eso_catalog.db")
+            with closing(sqlite3.connect(database)) as connection:
+                connection.executescript("""
+                    CREATE TABLE items (game_item_id INTEGER PRIMARY KEY);
+                    INSERT INTO items (game_item_id) VALUES (123);
+                    CREATE TABLE guild_trader_listings (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        game_item_id INTEGER,
+                        item_name TEXT,
+                        server TEXT,
+                        seller_name TEXT,
+                        price INTEGER,
+                        quantity INTEGER,
+                        active_stacks INTEGER,
+                        guild_name TEXT,
+                        location TEXT,
+                        level INTEGER,
+                        quality INTEGER,
+                        trait_id INTEGER,
+                        expires_at TEXT,
+                        discovered_at TEXT,
+                        UNIQUE(game_item_id, server, guild_name, seller_name, price, quantity, level, quality, trait_id)
+                    );
+                """)
+
+            scan_time = int(time.time())
+            scan_rows = []
+            for index, uid in enumerate(("listing-uid-1", "listing-uid-2", "listing-uid-1", "listing-uid-2"), 1):
+                scan_rows.append(
+                    f'        [{index}] = {{ ["UID"] = "{uid}", ["ItemId"] = 123, '
+                    f'["Name"] = "Identical Stack Item", ["Price"] = 200, ["Qty"] = 2, '
+                    f'["Guild"] = "Regression Test Guild", ["Seller"] = "@StackSeller", '
+                    f'["Location"] = "Regression Trader", ["Level"] = 50, ["Quality"] = 4, '
+                    f'["Trait"] = 3, ["Time"] = {scan_time} }},\n'
+                )
+            content = (
+                'ESOTrade_SavedVariables = {\n'
+                '    ["Server"] = "NA",\n'
+                '    ["Scans"] = {\n'
+                + ''.join(scan_rows)
+                + '    },\n'
+                '}\n'
+            )
+
+            with mock.patch.dict(os.environ, {"ESOTRADE_AUTH_TOKEN": ""}), \
+                    mock.patch.object(parse_esotrade_addon, "DEFAULT_DB_PATH", database), \
+                    mock.patch("sys.stdout", io.StringIO()):
+                for _ in range(2):
+                    with open(saved_variables, "w", encoding="utf-8") as handle:
+                        handle.write(content)
+                    self.assertEqual(1, parse_esotrade_addon.parse_and_sync_esotrade(saved_variables))
+
+            with closing(sqlite3.connect(database)) as verification:
+                row = verification.execute("""
+                    SELECT quantity, active_stacks
+                    FROM guild_trader_listings
+                    WHERE game_item_id = 123
+                """).fetchone()
+            self.assertEqual((2, 2), row)
+
     def test_parser_does_not_rewrite_an_empty_scans_table(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             saved_variables = os.path.join(temp_dir, "ESOTrade.lua")

--- a/backend/database_helpers.js
+++ b/backend/database_helpers.js
@@ -1,0 +1,96 @@
+function normalizeSql(sql) {
+    return String(sql || "").replace(/\s+/g, " ").trim();
+}
+
+function sqliteDiagnostic(error) {
+    if (!error) return "code=UNKNOWN message=Unknown SQLite error";
+
+    const code = error.code || "UNKNOWN";
+    const errno = Number.isInteger(error.errno) ? ` errno=${error.errno}` : "";
+    const message = error.message || String(error);
+    return `code=${code}${errno} message=${message}`;
+}
+
+function addedColumnName(sql) {
+    const match = normalizeSql(sql).match(
+        /\bALTER\s+TABLE\b.+?\bADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"([^"]+)"|`([^`]+)`|\[([^\]]+)\]|([A-Za-z_][A-Za-z0-9_]*))/i
+    );
+    return match ? (match[1] || match[2] || match[3] || match[4]) : null;
+}
+
+function duplicateColumnName(error) {
+    if (!error || error.code !== "SQLITE_ERROR") return null;
+    const match = String(error.message || "").match(
+        /^(?:SQLITE_ERROR:\s*)?duplicate column name:\s*(?:"([^"]+)"|`([^`]+)`|\[([^\]]+)\]|([A-Za-z_][A-Za-z0-9_]*))\s*$/i
+    );
+    return match ? (match[1] || match[2] || match[3] || match[4]) : null;
+}
+
+function isExpectedDuplicateColumnError(error, sql) {
+    const expectedColumn = addedColumnName(sql);
+    const duplicateColumn = duplicateColumnName(error);
+    return Boolean(
+        expectedColumn
+        && duplicateColumn
+        && expectedColumn.toLowerCase() === duplicateColumn.toLowerCase()
+    );
+}
+
+function createSchemaMigrationRunner(database, options = {}) {
+    const logger = options.logger || console;
+    const onUnexpectedError = options.onUnexpectedError || null;
+
+    return function runSchemaMigration(name, sql, migrationOptions = {}) {
+        const params = migrationOptions.params || [];
+        const allowDuplicateColumn = migrationOptions.allowDuplicateColumn === true;
+
+        return new Promise((resolve) => {
+            database.run(sql, params, function migrationCallback(error) {
+                if (!error) {
+                    resolve({ status: "applied", name });
+                    return;
+                }
+
+                if (allowDuplicateColumn && isExpectedDuplicateColumnError(error, sql)) {
+                    const columnName = addedColumnName(sql);
+                    logger.info(`[DB MIGRATION] "${name}" already applied (column "${columnName}" exists).`);
+                    resolve({ status: "already-applied", name });
+                    return;
+                }
+
+                const statement = normalizeSql(sql);
+                const failure = {
+                    name,
+                    sql: statement,
+                    error
+                };
+                logger.error(
+                    `[DB MIGRATION] "${name}" failed: ${sqliteDiagnostic(error)}. Statement: ${statement}`
+                );
+                if (onUnexpectedError) onUnexpectedError(failure);
+                resolve({ status: "failed", ...failure });
+            });
+        });
+    };
+}
+
+async function rollbackTransaction(dbRun, context, originalError, logger = console) {
+    try {
+        await dbRun("ROLLBACK");
+        return true;
+    } catch (rollbackError) {
+        logger.error(
+            `[DB TRANSACTION] ${context} rollback failed. `
+            + `Original error: ${sqliteDiagnostic(originalError)}. `
+            + `Rollback error: ${sqliteDiagnostic(rollbackError)}.`
+        );
+        return false;
+    }
+}
+
+module.exports = {
+    createSchemaMigrationRunner,
+    isExpectedDuplicateColumnError,
+    rollbackTransaction,
+    sqliteDiagnostic
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,8 +24,10 @@ const bcrypt = require("bcryptjs");
 const { rateLimit } = require("express-rate-limit");
 const sqlite3 = require("sqlite3").verbose();
 const { seedCuratedMetaBuilds } = require("./curated_builds");
+const { createSchemaMigrationRunner, rollbackTransaction } = require("./database_helpers");
 const app = express();
 const PORT = process.env.PORT || 5001;
+let server = null;
 
 const BCRYPT_SALT_ROUNDS = 12;
 const BCRYPT_HASH_PATTERN = /^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/;
@@ -190,6 +192,7 @@ const dbPath = process.env.DB_PATH || path.join(__dirname, "exports", "eso_catal
 const db = new sqlite3.Database(dbPath, (err) => {
     if (err) {
         console.error("Error connecting to the database:", err.message);
+        process.exit(1);
     } else {
         console.log("Connected to the SQLite database at:", dbPath);
         // Explicitly enable Foreign Key constraints
@@ -203,6 +206,33 @@ const db = new sqlite3.Database(dbPath, (err) => {
         initializeDatabaseSchema();
     }
 });
+
+const schemaMigrationFailures = [];
+const runSchemaMigration = createSchemaMigrationRunner(db, {
+    onUnexpectedError: (failure) => schemaMigrationFailures.push(failure)
+});
+
+function abortStartupForSchemaFailures() {
+    const failedNames = schemaMigrationFailures.map((failure) => failure.name).join(", ");
+    console.error(
+        `[DB SCHEMA] Startup aborted after ${schemaMigrationFailures.length} unexpected migration failure(s): ${failedNames}.`
+    );
+
+    const closeDatabaseAndExit = () => {
+        db.close((closeErr) => {
+            if (closeErr) {
+                console.error(`[DB SCHEMA] Failed to close SQLite after migration failure: ${closeErr.message}`);
+            }
+            process.exit(1);
+        });
+    };
+
+    if (server && server.listening) {
+        server.close(closeDatabaseAndExit);
+    } else {
+        closeDatabaseAndExit();
+    }
+}
 
 /**
  * Reports and disables accounts whose stored credential is not bcrypt.
@@ -242,10 +272,7 @@ function scheduleLegacyPasswordRemediation() {
         const disabledPasswordHash = hashPassword(crypto.randomBytes(32).toString("hex"));
 
         const rollback = (migrationErr) => {
-            db.run("ROLLBACK;", (rollbackErr) => {
-                if (rollbackErr) {
-                    console.error("[AUTH MIGRATION] Rollback failed:", rollbackErr.message);
-                }
+            rollbackTransaction(dbRun, "Legacy-account remediation", migrationErr).finally(() => {
                 console.error("[AUTH MIGRATION] Failed to disable non-bcrypt accounts:", migrationErr.message);
             });
         };
@@ -300,9 +327,9 @@ function initializeDatabaseSchema() {
         `, (err) => {
             if (err) console.error("Error creating 'items' table:", err.message);
         });
-        db.run("ALTER TABLE items ADD COLUMN set_name TEXT;", () => {});
-        db.run("ALTER TABLE items ADD COLUMN type TEXT;", () => {});
-        db.run("ALTER TABLE items ADD COLUMN icon TEXT;", () => {});
+        runSchemaMigration("items.add-set-name", "ALTER TABLE items ADD COLUMN set_name TEXT;", { allowDuplicateColumn: true });
+        runSchemaMigration("items.add-type", "ALTER TABLE items ADD COLUMN type TEXT;", { allowDuplicateColumn: true });
+        runSchemaMigration("items.add-icon", "ALTER TABLE items ADD COLUMN icon TEXT;", { allowDuplicateColumn: true });
         db.run("CREATE INDEX IF NOT EXISTS idx_items_name ON items(name);");
         db.run("CREATE INDEX IF NOT EXISTS idx_items_category ON items(category);");
         db.run("CREATE INDEX IF NOT EXISTS idx_items_set_name ON items(set_name);");
@@ -413,9 +440,9 @@ function initializeDatabaseSchema() {
             else console.log("'characters' table initialized successfully.");
         });
 
-        db.run("ALTER TABLE characters ADD COLUMN user_id INTEGER DEFAULT 1;", () => {});
-        db.run("ALTER TABLE characters ADD COLUMN alliance INTEGER DEFAULT 1;", () => {});
-        db.run("ALTER TABLE characters ADD COLUMN master_crafter_unlocked INTEGER DEFAULT 0;", () => {});
+        runSchemaMigration("characters.add-user-id", "ALTER TABLE characters ADD COLUMN user_id INTEGER DEFAULT 1;", { allowDuplicateColumn: true });
+        runSchemaMigration("characters.add-alliance", "ALTER TABLE characters ADD COLUMN alliance INTEGER DEFAULT 1;", { allowDuplicateColumn: true });
+        runSchemaMigration("characters.add-master-crafter-unlocked", "ALTER TABLE characters ADD COLUMN master_crafter_unlocked INTEGER DEFAULT 0;", { allowDuplicateColumn: true });
 
         db.run(`
             CREATE TABLE IF NOT EXISTS knowledge (
@@ -452,15 +479,16 @@ function initializeDatabaseSchema() {
                 UNIQUE(character_id, slot_id)
             );
         `, (err) => {
-            db.run("ALTER TABLE character_gear ADD COLUMN item_icon TEXT", () => {});
-            db.run("ALTER TABLE character_gear ADD COLUMN trait_name TEXT", () => {});
-            db.run("ALTER TABLE character_gear ADD COLUMN trait_description TEXT", () => {});
-            db.run("ALTER TABLE character_gear ADD COLUMN armor_rating INTEGER DEFAULT 0", () => {});
-            db.run("ALTER TABLE character_gear ADD COLUMN weapon_power INTEGER DEFAULT 0", () => {});
-            db.run("UPDATE items SET icon_url = REPLACE(icon_url, '.dds', '.png') WHERE icon_url LIKE '%.dds'", () => {});
-            db.run("UPDATE character_gear SET item_icon = REPLACE(item_icon, '.dds', '.png') WHERE item_icon LIKE '%.dds'", () => {});
-            console.log("'character_gear' table initialized successfully.");
+            if (err) console.error("Error creating 'character_gear' table:", err.message);
+            else console.log("'character_gear' table initialized successfully.");
         });
+        runSchemaMigration("character-gear.add-item-icon", "ALTER TABLE character_gear ADD COLUMN item_icon TEXT", { allowDuplicateColumn: true });
+        runSchemaMigration("character-gear.add-trait-name", "ALTER TABLE character_gear ADD COLUMN trait_name TEXT", { allowDuplicateColumn: true });
+        runSchemaMigration("character-gear.add-trait-description", "ALTER TABLE character_gear ADD COLUMN trait_description TEXT", { allowDuplicateColumn: true });
+        runSchemaMigration("character-gear.add-armor-rating", "ALTER TABLE character_gear ADD COLUMN armor_rating INTEGER DEFAULT 0", { allowDuplicateColumn: true });
+        runSchemaMigration("character-gear.add-weapon-power", "ALTER TABLE character_gear ADD COLUMN weapon_power INTEGER DEFAULT 0", { allowDuplicateColumn: true });
+        runSchemaMigration("items.normalize-icon-extension", "UPDATE items SET icon_url = REPLACE(icon_url, '.dds', '.png') WHERE icon_url LIKE '%.dds'");
+        runSchemaMigration("character-gear.normalize-icon-extension", "UPDATE character_gear SET item_icon = REPLACE(item_icon, '.dds', '.png') WHERE item_icon LIKE '%.dds'");
 
         db.run(`
             CREATE TABLE IF NOT EXISTS guild_trader_listings (
@@ -490,7 +518,7 @@ function initializeDatabaseSchema() {
         });
 
         // Ensure item_name column exists for dynamic in-game item naming
-        db.run(`ALTER TABLE guild_trader_listings ADD COLUMN item_name TEXT`, () => {});
+        runSchemaMigration("guild-trader-listings.add-item-name", "ALTER TABLE guild_trader_listings ADD COLUMN item_name TEXT", { allowDuplicateColumn: true });
 
         db.run(`
             CREATE TABLE IF NOT EXISTS user_inventory (
@@ -536,11 +564,11 @@ function initializeDatabaseSchema() {
         }
 
         // Migration columns for existing databases
-        db.run("ALTER TABLE guild_trader_listings ADD COLUMN seller_name TEXT DEFAULT '@Unknown';", (err) => {});
-        db.run("ALTER TABLE guild_trader_listings ADD COLUMN active_stacks INTEGER DEFAULT 1;", (err) => {});
-        db.run("ALTER TABLE guild_trader_listings ADD COLUMN level INTEGER DEFAULT 1;", (err) => {});
-        db.run("ALTER TABLE guild_trader_listings ADD COLUMN quality INTEGER DEFAULT 1;", (err) => {});
-        db.run("ALTER TABLE guild_trader_listings ADD COLUMN trait_id INTEGER DEFAULT 0;", (err) => {});
+        runSchemaMigration("guild-trader-listings.add-seller-name", "ALTER TABLE guild_trader_listings ADD COLUMN seller_name TEXT DEFAULT '@Unknown';", { allowDuplicateColumn: true });
+        runSchemaMigration("guild-trader-listings.add-active-stacks", "ALTER TABLE guild_trader_listings ADD COLUMN active_stacks INTEGER DEFAULT 1;", { allowDuplicateColumn: true });
+        runSchemaMigration("guild-trader-listings.add-level", "ALTER TABLE guild_trader_listings ADD COLUMN level INTEGER DEFAULT 1;", { allowDuplicateColumn: true });
+        runSchemaMigration("guild-trader-listings.add-quality", "ALTER TABLE guild_trader_listings ADD COLUMN quality INTEGER DEFAULT 1;", { allowDuplicateColumn: true });
+        runSchemaMigration("guild-trader-listings.add-trait-id", "ALTER TABLE guild_trader_listings ADD COLUMN trait_id INTEGER DEFAULT 0;", { allowDuplicateColumn: true });
 
         // Builds, Build Items & User Saved Builds Schema
         db.run(`
@@ -587,13 +615,11 @@ function initializeDatabaseSchema() {
             );
         `, (err) => {
             if (err) console.error("Error creating 'build_items' table:", err.message);
-            else {
-                console.log("'build_items' table initialized successfully.");
-                db.run("ALTER TABLE build_items ADD COLUMN item_icon TEXT", () => {});
-                db.run("ALTER TABLE build_items ADD COLUMN armor_weight TEXT", () => {});
-                db.run("ALTER TABLE build_items ADD COLUMN weapon_type TEXT", () => {});
-            }
+            else console.log("'build_items' table initialized successfully.");
         });
+        runSchemaMigration("build-items.add-item-icon", "ALTER TABLE build_items ADD COLUMN item_icon TEXT", { allowDuplicateColumn: true });
+        runSchemaMigration("build-items.add-armor-weight", "ALTER TABLE build_items ADD COLUMN armor_weight TEXT", { allowDuplicateColumn: true });
+        runSchemaMigration("build-items.add-weapon-type", "ALTER TABLE build_items ADD COLUMN weapon_type TEXT", { allowDuplicateColumn: true });
 
         db.run(`
             CREATE TABLE IF NOT EXISTS user_saved_builds (
@@ -708,6 +734,21 @@ function initializeDatabaseSchema() {
                 DELETE FROM guild_trader_listings WHERE id = NEW.id;
             END;
         `);
+
+        // This sentinel runs after every queued schema statement. Unexpected
+        // migration failures are fatal so the API never serves a partial schema.
+        db.run("SELECT 1;", (finalizeErr) => {
+            if (finalizeErr) {
+                console.error(`[DB SCHEMA] Finalization check failed: ${finalizeErr.message}`);
+                schemaMigrationFailures.push({ name: "schema.finalization", error: finalizeErr });
+            }
+            if (schemaMigrationFailures.length > 0) {
+                abortStartupForSchemaFailures();
+            } else {
+                console.log("[DB SCHEMA] Schema initialization completed successfully.");
+                startServer();
+            }
+        });
     });
 }
 
@@ -1059,11 +1100,7 @@ app.post("/api/characters/sync", async (req, res) => {
         await dbRun("COMMIT");
         res.json({ success: true, character_id: characterId });
     } catch (err) {
-        try {
-            await dbRun("ROLLBACK");
-        } catch (rollbackErr) {
-            console.error("Rollback failed:", rollbackErr.message);
-        }
+        await rollbackTransaction(dbRun, "POST /api/characters/sync", err);
         console.error("Error syncing character:", err.message);
         res.status(500).json({ error: err.message });
     }
@@ -1213,7 +1250,8 @@ app.post("/api/characters/upload-gear", batchUploadLimiter, async (req, res) => 
 
         res.json({ success: true, character_id: characterId, slots_updated: gear.length });
     } catch (err) {
-        try { await dbRun("ROLLBACK"); } catch (rErr) {}
+        await rollbackTransaction(dbRun, "POST /api/characters/upload-gear", err);
+        console.error("Error uploading character gear:", err.message);
         res.status(500).json({ error: err.message });
     }
 });
@@ -1281,7 +1319,8 @@ app.post("/api/characters/upload-traits", batchUploadLimiter, async (req, res) =
 
         res.json({ success: true, character_id: characterId, traits_updated: traits.length });
     } catch (err) {
-        try { await dbRun("ROLLBACK"); } catch (rErr) {}
+        await rollbackTransaction(dbRun, "POST /api/characters/upload-traits", err);
+        console.error("Error uploading character traits:", err.message);
         res.status(500).json({ error: err.message });
     }
 });
@@ -1388,11 +1427,7 @@ app.post("/api/listings/sync", async (req, res) => {
         await dbRun("COMMIT");
         res.json({ success: true, count: listings.length });
     } catch (err) {
-        try {
-            await dbRun("ROLLBACK");
-        } catch (rollbackErr) {
-            console.error("Rollback failed:", rollbackErr.message);
-        }
+        await rollbackTransaction(dbRun, "POST /api/listings/sync", err);
         console.error("Error syncing listings:", err.message);
         res.status(500).json({ error: err.message });
     }
@@ -1460,11 +1495,7 @@ app.post("/api/inventory/sync", async (req, res) => {
         await dbRun("COMMIT");
         res.json({ success: true, count: inventory.length });
     } catch (err) {
-        try {
-            await dbRun("ROLLBACK");
-        } catch (rollbackErr) {
-            console.error("Rollback failed:", rollbackErr.message);
-        }
+        await rollbackTransaction(dbRun, "POST /api/inventory/sync", err);
         console.error("Error syncing inventory:", err.message);
         res.status(500).json({ error: err.message });
     }
@@ -3308,7 +3339,8 @@ app.post("/api/builds", async (req, res) => {
         await dbRun("COMMIT");
         res.json({ success: true, build_id: buildId, message: "Custom build saved successfully." });
     } catch (err) {
-        await dbRun("ROLLBACK");
+        await rollbackTransaction(dbRun, "POST /api/builds", err);
+        console.error("Error creating custom build:", err.message);
         res.status(500).json({ error: err.message });
     }
 });
@@ -3818,7 +3850,8 @@ app.post("/api/characters/:id/traits", async (req, res) => {
             message: `Successfully updated ${traitUpdates.length} trait(s).`
         });
     } catch (err) {
-        await dbRun("ROLLBACK").catch(() => {});
+        await rollbackTransaction(dbRun, "POST /api/characters/:id/traits", err);
+        console.error("Error updating character traits:", err.message);
         res.status(500).json({ error: err.message });
     }
 });
@@ -4439,14 +4472,17 @@ app.delete("/api/requests/:id", async (req, res) => {
     });
 });
 
-const server = app.listen(PORT, () => {
-    console.log(`Server is running on port ${PORT}`);
-});
+function startServer() {
+    if (server) return server;
+    server = app.listen(PORT, () => {
+        console.log(`Server is running on port ${PORT}`);
+    });
+    return server;
+}
 
 const gracefulShutdown = (signal) => {
     console.log(`\n[API SERVER] Received ${signal}. Starting graceful shutdown...`);
-    server.close(() => {
-        console.log("[API SERVER] HTTP server closed.");
+    const closeDatabase = () => {
         if (db) {
             db.close((err) => {
                 if (err) {
@@ -4460,7 +4496,16 @@ const gracefulShutdown = (signal) => {
         } else {
             process.exit(0);
         }
-    });
+    };
+
+    if (server) {
+        server.close(() => {
+            console.log("[API SERVER] HTTP server closed.");
+            closeDatabase();
+        });
+    } else {
+        closeDatabase();
+    }
 
     // Fallback if shutdown hangs after 5 seconds
     setTimeout(() => {
@@ -4472,4 +4517,8 @@ const gracefulShutdown = (signal) => {
 process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
 process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 
-module.exports = { app, server, gracefulShutdown };
+module.exports = {
+    app,
+    get server() { return server; },
+    gracefulShutdown
+};


### PR DESCRIPTION
## Summary
- route every legacy schema change through a shared migration runner with exact duplicate-column verification
- include migration names, normalized SQL, and SQLite diagnostics for unexpected failures, and delay HTTP startup until schema initialization succeeds
- route every transactional rollback through a shared helper that preserves both the original request error and rollback failure context
- add SQLite regression coverage for expected duplicates, unexpected migration failures, mismatched duplicate errors, and rollback failures

## Verification
- `npm test` (`backend`)
- `python test_db_queries.py`
- `python test_watcher.py`
- `npm run build` (`frontend`)
- `node --check backend/database_helpers.js`
- `node --check backend/server.js`
- `node --check backend/data-pipeline/test_api_endpoints.js`

Closes #70
## Follow-up: Idempotent Guild Trader Stack Counts
- serialize ESO's per-listing UID from the addon so repeated response callbacks can be recognized
- keep the newest observation for a repeated UID without adding another active stack
- preserve separate identical listings because distinct UIDs still count as distinct stacks
- add a regression that replays two identical stacks twice and verifies `active_stacks` remains `2`
- bump the addon version to `1.6.1`